### PR TITLE
Kvk mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,30 @@ Upcoming changes for this documentation are published (build) at: https://build.
 
 The build-logs of this build are published on https://chat.fhir.org/#narrow/stream/179297-committers.2Fnotification/topic/ig-build (could take 2-3 minutes after a commit to the repo)
 In the ./build.log you can find the build log. Validation tests are in ./output/qa.html
+
+
+# Generating FSH-FHIR-resources on your desktop
+
+If you want to generate FSH FHIR-resources based on Simplifier-FHIR-profiles (like the Dutch 'nl-core' profiles) on your local desktop, you have to [install Dotnet & Firely Terminal](https://docs.fire.ly/projects/Firely-Terminal/getting_started/InstallingFirelyTerminal.html):
+```
+sudo apt-get install -y dotnet-sdk-8.0
+echo 'export PATH=$PATH:~/.dotnet/tools' >> ~/.bashrc
+echo "-----reload bash configuration file"
+source ~/.bashrc
+```
+create a snapshot of the Dutch profiles using 
+```
+fhir install nictiz.fhir.nl.r4.nl-core 0.12.0-beta.1
+```
+
+[Install NodeJS & Sushi](https://fshschool.org/docs/sushi/installation/) to generate FHIR-resource from FSH-files (it will need the snapshots you've just created):
+```
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - &&\
+sudo apt-get install -y nodejs
+sudo npm install -g npm@latest 
+sudo npm install -g fsh-sushi
+```
+now you should be able to generate fhir resources from fsh-files using
+```
+sushi .
+```

--- a/input/fsh/examples/phi-org1.fsh
+++ b/input/fsh/examples/phi-org1.fsh
@@ -117,31 +117,6 @@ Title: "MedicationStatement Urokinase"
 * dosage[0].doseAndRate[0].doseQuantity.unit = "mg"
 
 
-
-Instance: f304c628-c19f-4207-adfb-ad34447ab044
-InstanceOf: CareTeam
-Usage: #inline
-Title: "CareTeam of Patient Jaantje Merkens"
-* insert AuthorAssignedIdentifier("http://organization1.example.org/EHR/careteams","f304c628-c19f-4207-adfb-ad34447ab044","http://fhir.nl/fhir/NamingSystem/ura", "11111111")
-* participant[+].period.start = "2024-08-27"
-* participant[=].member = Reference(Patient/128447d2-e153-4c93-8ac6-6c357555f3db)
-* participant[+].period.start = "2024-08-27"
-* participant[=].member = Reference(PractitionerRole/5fa4c91a-a12f-48ae-a4c7-92971dc7ab53)
-* participant[+].period.start = "2024-08-27"
-* insert RefAuthorAssignedIdentifier(participant[=].member, "https://cp2-test.example.org/employees", "f051d3bd-26ff-4030-a5b6-fc4ef2be83ba", "http://fhir.nl/fhir/NamingSystem/ura","22222222","Cardioloog Caroline van Dijk at Organization 2")
-* participant[+].period.start = "2024-08-27"
-* insert RefAuthorAssignedIdentifier(participant[=].member, "https://cp3-test.example.org/employees", "d60525bd-5caf-4437-8f4b-4156300a27de", "http://fhir.nl/fhir/NamingSystem/ura","33333333", "Klinisch geriater John Doe at Organization 3")
-
-* participant[+].period.start = "2024-08-27"
-* participant[=].member = Reference(Organization/4cb35b96-f021-4e15-bf71-d67a6d4bebec)
-* participant[=].member.identifier.system = "http://fhir.nl/fhir/NamingSystem/ura"
-* participant[=].member.identifier.value = "11111111"
-* participant[+].period.start = "2024-08-27"
-* insert RefAuthorAssignedIdentifier(participant[=].member, "https://cp2-test.example.org/departments", "cff921f3-c1c1-4a4c-8f0f-cafd0aa25067", "http://fhir.nl/fhir/NamingSystem/ura","22222222","example Hospital")
-
-
-
-
 Instance: phi-org1
 InstanceOf: Bundle
 Usage: #example
@@ -155,4 +130,3 @@ Description: "This bundle contains all personal health information for Patient J
 * insert BundleEntryPUT(ServiceRequest, 4e4215a2-d6ff-4e53-8737-d9810a4cc3eb)
 * insert BundleEntryPUT(ServiceRequest, 3cb7873f-c222-4196-b441-02b3790ec97e)
 * insert BundleEntryPUT(MedicationStatement, 98f9d4a7-d58d-4889-8e63-0cb2d4e35144)
-* insert BundleEntryPUT(CareTeam, f304c628-c19f-4207-adfb-ad34447ab044)

--- a/input/fsh/rulesets.fsh
+++ b/input/fsh/rulesets.fsh
@@ -54,21 +54,22 @@ RuleSet: BundleEntryWithFullurl (fullUrl, resource, method, url)
 * entry[=].request.url = "{url}"
 
 
-
 RuleSet: AuthorAssignedIdentifier (system, value, assigner-system, assigner-value)
 * identifier[+].system = {system}
 * identifier[=].value = {value}
+* identifier[=].use = #official
 * identifier[=].assigner.identifier.system = {assigner-system}
 * identifier[=].assigner.identifier.value = {assigner-value}
 * identifier[=].assigner.identifier.type = $provenance-participant-type#author
 
-RuleSet: RefAuthorAssignedIdentifier (resource-element, system, value, assigner-system, assigner-value, display)
-* {resource-element}.identifier.system = {system}
-* {resource-element}.identifier.value = {value}
-* {resource-element}.identifier.assigner.identifier.system = {assigner-system}
-* {resource-element}.identifier.assigner.identifier.value = {assigner-value}
-* {resource-element}.identifier.assigner.identifier.type = $provenance-participant-type#author
-* {resource-element}.display = {display}
+// RuleSet: RefAuthorAssignedIdentifier (resource-element, system, value, assigner-system, assigner-value, display)
+// * {resource-element}.identifier.system = {system}
+// * {resource-element}.identifier.value = {value}
+// * {resource-element}.identifier.use = #official
+// * {resource-element}.identifier.assigner.identifier.system = {assigner-system}
+// * {resource-element}.identifier.assigner.identifier.value = {assigner-value}
+// * {resource-element}.identifier.assigner.identifier.type = $provenance-participant-type#author
+// * {resource-element}.display = {display}
 
 RuleSet: RefIdentifier (resource-element, resource-type, instance-number, identifier-system, identifier-value, assigner-system, assigner-value, source)
 * {resource-element} = Reference({{{source}-fhir-url}}{resource-type}/{{{resource-type}{instance-number}}})

--- a/input/fsh/structuredefinitions.fsh
+++ b/input/fsh/structuredefinitions.fsh
@@ -22,7 +22,7 @@ Id: nl-gf-healthcareservice
 Title: "NL Generic Functions HealthcareService Profile"
 Description: "The technical details of a healthcare service that can be used in referrals, requests and orders"
 * ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-compliesWithProfile].valueCanonical = "https://profiles.ihe.net/ITI/mCSD/StructureDefinition/IHE.mCSD.HealthcareService"
-* identifier ^slicing.discriminator.type = #value
+* identifier ^slicing.discriminator.type = #profile
 * identifier ^slicing.discriminator.path = "$this"
 * identifier ^slicing.rules = #open
 * identifier contains
@@ -45,7 +45,7 @@ Id: nl-gf-location
 Title: "NL Generic Functions Location Profile"
 Description: "Physical location details for healthcare services, organizations, and practitioners."
 * ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-compliesWithProfile].valueCanonical = "https://profiles.ihe.net/ITI/mCSD/StructureDefinition/IHE.mCSD.Location"
-* identifier ^slicing.discriminator.type = #value
+* identifier ^slicing.discriminator.type = #profile
 * identifier ^slicing.discriminator.path = "$this"
 * identifier ^slicing.rules = #open
 * identifier contains
@@ -100,7 +100,12 @@ can be accessed for localization purposes."""
 
 Invariant:   ura-identifier-or-partof
 Description: "an Organization instance must either have an URA-identifier or must be 'partOf' some other instance that is an nl-gf-organization instance."
-Expression:  "identifier.where(system='http://fhir.nl/fhir/NamingSystem/ura').exists() or partOf.exists()"
+Expression:  "identifier.where(system='http://fhir.nl/fhir/NamingSystem/ura').exists() or identifier.where(system='http://fhir.nl/fhir/NamingSystem/kvk').exists() or partOf.exists()"
+Severity:    #error
+
+Invariant:   assigner-identifier-system
+Description: "The assigner identifier system must be either URA or KVK."
+Expression:  "system = 'http://fhir.nl/fhir/NamingSystem/ura' or system = 'http://fhir.nl/fhir/NamingSystem/kvk'"
 Severity:    #error
 
 Profile: NlGfOrganization
@@ -110,22 +115,20 @@ Title: "NL Generic Functions Organization Profile"
 Description: "The organizational hierarchy and details for healthcare organizations."
 * ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-compliesWithProfile].valueCanonical = "https://profiles.ihe.net/ITI/mCSD/StructureDefinition/IHE.mCSD.Organization"
 * obeys ura-identifier-or-partof
-* identifier ^slicing.discriminator.type = #value
-* identifier ^slicing.discriminator.path = "$this"
-* identifier ^slicing.rules = #open
-* identifier contains
-    AssignedId 1..1
-* identifier[AssignedId] only AuthorAssignedIdentifier
+// * identifier ^slicing.discriminator[+].type = #profile
+// * identifier ^slicing.discriminator[=].path = "$this"
+// * identifier ^slicing.rules = #open
+// * identifier contains
+//     AssignedId 1..1
+// * identifier[AssignedId] only AuthorAssignedIdentifier
 * implicitRules ..0 //compliance to https://profiles.ihe.net/ITI/mCSD/StructureDefinition/IHE.mCSD.Organization
 * modifierExtension ..0 //compliance to https://profiles.ihe.net/ITI/mCSD/StructureDefinition/IHE.mCSD.Organization
 * name 1.. //compliance to https://profiles.ihe.net/ITI/mCSD/StructureDefinition/IHE.mCSD.Organization
 * type 1.. //compliance to https://profiles.ihe.net/ITI/mCSD/StructureDefinition/IHE.mCSD.Organization
-* type ^slicing.discriminator.type = #value
-* type ^slicing.discriminator.path = "$this"
-* type ^slicing.rules = #open
 * type contains
     SBI 0..1
 * type[SBI] from NlGfOrgTypesVS (extensible)
+* type[SBI] ^patternCodeableConcept.coding.system = "http://minvws.github.io/generiekefuncties-docs/CodeSystem/nl-gf-sbi-2025-cs"
 * type[SBI] ^short = "SBI"
 * type[SBI] ^definition = "CBS Standaard Bedrijfsindeling code representing the primary activity of the organization."
 * type[SBI] ^alias = "Standaard Bedrijfsindeling"
@@ -139,7 +142,7 @@ Id: nl-gf-organizationaffiliation
 Title: "NL Generic Functions OrganizationAffiliation Profile"
 Description: "The details of an affiliation/relationship between two organizations, such as a healthcare provider and a software vendor."
 * ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-compliesWithProfile].valueCanonical = "https://profiles.ihe.net/ITI/mCSD/StructureDefinition/IHE.mCSD.OrganizationAffiliation"
-* identifier ^slicing.discriminator.type = #value
+* identifier ^slicing.discriminator.type = #profile
 * identifier ^slicing.discriminator.path = "$this"
 * identifier ^slicing.rules = #open
 * identifier contains
@@ -170,7 +173,7 @@ Id: nl-gf-practitionerrole
 Title: "NL Generic Functions PractitionerRole Profile"
 Description: "The details of a healthcare practitioner's role within an organization."
 * ^extension[http://hl7.org/fhir/StructureDefinition/structuredefinition-compliesWithProfile].valueCanonical = "https://profiles.ihe.net/ITI/mCSD/StructureDefinition/IHE.mCSD.PractitionerRole"
-* identifier ^slicing.discriminator.type = #value
+* identifier ^slicing.discriminator.type = #profile
 * identifier ^slicing.discriminator.path = "$this"
 * identifier ^slicing.rules = #open
 * identifier contains
@@ -215,7 +218,8 @@ Description: """Identifier assigned by the author of a resource, such as a healt
 * value 1..
 * assigner 1..1
 * assigner.identifier 1..1
-* assigner.identifier.system = "http://fhir.nl/fhir/NamingSystem/ura"
+* assigner.identifier obeys assigner-identifier-system
+* assigner.identifier.system 1..1
 * assigner.identifier.value 1..1
 * assigner.identifier.type 1..1
 * assigner.identifier.type.coding 1..1

--- a/input/fsh/structuremaps.fsh
+++ b/input/fsh/structuremaps.fsh
@@ -1,0 +1,1081 @@
+// ============================================================================
+// Logical Model: KVK Basisprofiel (source structure for StructureMap)
+// ============================================================================
+
+Logical: KvkBasisprofiel
+Id: kvk-basisprofiel
+Title: "KVK Basisprofiel"
+Description: "Logical model representing the KVK (Kamer van Koophandel) Basisprofiel API response structure as defined in the KVK API v1.4.0."
+* kvkNummer 0..1 string "Nederlands Kamer van Koophandel nummer: bestaat uit 8 cijfers"
+* indNonMailing 0..1 string "Indicatie geen ongevraagde reclame per post of verkoop aan de deur"
+* naam 0..1 string "Naam onder Maatschappelijke Activiteit"
+* formeleRegistratiedatum 0..1 string "Registratiedatum onderneming in het Handelsregister"
+* materieleRegistratie 0..1 BackboneElement "Materiële registratie datums"
+  * datumAanvang 0..1 string "Startdatum onderneming"
+  * datumEinde 0..1 string "Einddatum onderneming"
+* totaalWerkzamePersonen 0..1 integer "Totaal aantal werkzame personen"
+* statutaireNaam 0..1 string "De naam van de onderneming wanneer er statuten geregistreerd zijn"
+* handelsnamen 0..* BackboneElement "Alle namen waaronder een onderneming of vestiging handelt (op volgorde van registreren)"
+  * naam 0..1 string "Handelsnaam"
+  * volgorde 0..1 integer "Volgorde van registreren"
+* sbiActiviteiten 0..* BackboneElement "SBI activiteiten conform SBI 2008 (Standard Industrial Classification)"
+  * sbiCode 0..1 string "SBI code"
+  * sbiOmschrijving 0..1 string "SBI omschrijving"
+  * indHoofdactiviteit 0..1 string "Indicatie hoofdactiviteit"
+* embedded 0..1 BackboneElement "Embedded resources (_embedded)"
+  * hoofdvestiging 0..1 BackboneElement "Hoofdvestiging informatie"
+    * vestigingsnummer 0..1 string "Vestigingsnummer: uniek nummer van 12 cijfers"
+    * kvkNummer 0..1 string "KVK nummer"
+    * rsin 0..1 string "Rechtspersonen Samenwerkingsverbanden Informatie Nummer"
+    * eersteHandelsnaam 0..1 string "De naam waaronder een onderneming of vestiging handelt"
+    * formeleRegistratiedatum 0..1 string "Registratiedatum onderneming in HR"
+    * statutaireNaam 0..1 string "Statutaire naam"
+    * indHoofdvestiging 0..1 string "Indicatie hoofdvestiging (Ja/Nee)"
+    * indCommercieleVestiging 0..1 string "Indicatie commerciële vestiging (Ja/Nee)"
+    * voltijdWerkzamePersonen 0..1 integer "Voltijd werkzame personen"
+    * totaalWerkzamePersonen 0..1 integer "Totaal werkzame personen"
+    * deeltijdWerkzamePersonen 0..1 integer "Deeltijd werkzame personen"
+    * adressen 0..* BackboneElement "Adressen van de vestiging"
+      * type 0..1 string "Correspondentieadres en/of bezoekadres"
+      * indAfgeschermd 0..1 string "Indicatie of het adres is afgeschermd"
+      * volledigAdres 0..1 string "Volledig adres"
+      * straatnaam 0..1 string "Straatnaam"
+      * huisnummer 0..1 integer "Huisnummer"
+      * huisletter 0..1 string "Huisletter"
+      * huisnummerToevoeging 0..1 string "Huisnummer toevoeging"
+      * postcode 0..1 string "Postcode"
+      * plaats 0..1 string "Plaats"
+      * land 0..1 string "Land"
+    * websites 0..* string "Websites"
+  * eigenaar 0..1 BackboneElement "Eigenaar informatie"
+    * rsin 0..1 string "Rechtspersonen Samenwerkingsverbanden Informatie Nummer"
+    * rechtsvorm 0..1 string "Rechtsvorm"
+    * uitgebreideRechtsvorm 0..1 string "Uitgebreide rechtsvorm"
+    * adressen 0..* BackboneElement "Adressen van de eigenaar"
+      * type 0..1 string "Type adres"
+      * indAfgeschermd 0..1 string "Indicatie of het adres is afgeschermd"
+      * volledigAdres 0..1 string "Volledig adres"
+      * straatnaam 0..1 string "Straatnaam"
+      * huisnummer 0..1 integer "Huisnummer"
+      * huisletter 0..1 string "Huisletter"
+      * huisnummerToevoeging 0..1 string "Huisnummer toevoeging"
+      * postcode 0..1 string "Postcode"
+      * plaats 0..1 string "Plaats"
+      * land 0..1 string "Land"
+    * websites 0..* string "Websites van de eigenaar"
+
+// ============================================================================
+// StructureMap: KVK Basisprofiel → FHIR Organization
+//
+// Mapping summary:
+//   kvkNummer                          → Organization.identifier (system: kvk)
+//   naam                               → Organization.name
+//   statutaireNaam                      → Organization.alias
+//   handelsnamen[].naam                 → Organization.alias
+//   sbiActiviteiten[]                   → Organization.type (SBI CodeSystem)
+//   embedded.hoofdvestiging.adressen[]  → Organization.address
+//   embedded.hoofdvestiging.websites[]  → Organization.telecom (system: url)
+//   active                             → true (default)
+// ============================================================================
+
+Instance: KvkBasisprofielToOrganization
+InstanceOf: StructureMap
+Usage: #definition
+Title: "KVK Basisprofiel naar FHIR Organization"
+Description: "StructureMap die een KVK Basisprofiel API response transformeert naar een FHIR Organization resource."
+* url = "http://minvws.github.io/generiekefuncties-docs/StructureMap/KvkBasisprofielToOrganization"
+* name = "KvkBasisprofielToOrganization"
+* status = #draft
+* structure[+].url = "http://minvws.github.io/generiekefuncties-docs/StructureDefinition/kvk-basisprofiel"
+* structure[=].mode = #source
+* structure[=].alias = "KvkBasisprofiel"
+* structure[+].url = Canonical(NlGfOrganization)
+* structure[=].mode = #target
+* structure[=].alias = "NlGfOrganization"
+
+// ── Group 0: Main mapping KvkBasisprofiel → Organization ────────────────────
+* group[+].name = "KvkBasisprofielToOrganization"
+* group[=].typeMode = #none
+* group[=].input[+].name = "src"
+* group[=].input[=].type = "KvkBasisprofiel"
+* group[=].input[=].mode = #source
+* group[=].input[+].name = "tgt"
+* group[=].input[=].type = "Organization"
+* group[=].input[=].mode = #target
+
+// Rule: kvkNummer → identifier (system: http://fhir.nl/fhir/NamingSystem/kvk)
+* group[=].rule[+].name = "kvkNummer"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "kvkNummer"
+* group[=].rule[=].source[=].variable = "kvkNum"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "identifier"
+* group[=].rule[=].target[=].variable = "kvkId"
+* group[=].rule[=].rule[+].name = "kvkSystem"
+* group[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].target[+].context = "kvkId"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "system"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://fhir.nl/fhir/NamingSystem/kvk"
+* group[=].rule[=].rule[+].name = "kvkValue"
+* group[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].target[+].context = "kvkId"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "value"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueId = "kvkNum"
+
+// Rule: naam → name
+* group[=].rule[+].name = "naam"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "naam"
+* group[=].rule[=].source[=].variable = "naam"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "name"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "naam"
+
+// Rule: active = true
+* group[=].rule[+].name = "setActive"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "active"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueBoolean = true
+
+// Rule: statutaireNaam → alias
+* group[=].rule[+].name = "statutaireNaam"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "statutaireNaam"
+* group[=].rule[=].source[=].variable = "statNaam"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "alias"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "statNaam"
+
+// Rule: handelsnamen → alias (via dependent group)
+* group[=].rule[+].name = "handelsnamen"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "handelsnamen"
+* group[=].rule[=].source[=].variable = "hn"
+* group[=].rule[=].dependent[+].name = "KvkHandelsnaamToAlias"
+* group[=].rule[=].dependent[=].variable[+] = "hn"
+* group[=].rule[=].dependent[=].variable[+] = "tgt"
+
+// Rule: sbiActiviteiten → type (via dependent group)
+* group[=].rule[+].name = "sbiActiviteiten"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "sbiActiviteiten"
+* group[=].rule[=].source[=].variable = "sbi"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "type"
+* group[=].rule[=].target[=].variable = "cc"
+* group[=].rule[=].dependent[+].name = "KvkSBIToCodeableConcept"
+* group[=].rule[=].dependent[=].variable[+] = "sbi"
+* group[=].rule[=].dependent[=].variable[+] = "cc"
+
+// Rule: embedded → eigenaar + hoofdvestiging (nested rules)
+* group[=].rule[+].name = "embedded"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "embedded"
+* group[=].rule[=].source[=].variable = "emb"
+
+// // Nested: eigenaar.rsin → identifier (system: rsin)
+// * group[=].rule[=].rule[+].name = "eigenaar"
+// * group[=].rule[=].rule[=].source[+].context = "emb"
+// * group[=].rule[=].rule[=].source[=].element = "eigenaar"
+// * group[=].rule[=].rule[=].source[=].variable = "eig"
+// * group[=].rule[=].rule[=].rule[+].name = "rsin"
+// * group[=].rule[=].rule[=].rule[=].source[+].context = "eig"
+// * group[=].rule[=].rule[=].rule[=].source[=].element = "rsin"
+// * group[=].rule[=].rule[=].rule[=].source[=].variable = "rsin"
+// * group[=].rule[=].rule[=].rule[=].target[+].context = "tgt"
+// * group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+// * group[=].rule[=].rule[=].rule[=].target[=].element = "identifier"
+// * group[=].rule[=].rule[=].rule[=].target[=].variable = "rsinId"
+// * group[=].rule[=].rule[=].rule[=].rule[+].name = "rsinSystem"
+// * group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "rsin"
+// * group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "rsinId"
+// * group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+// * group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "system"
+// * group[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+// * group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://fhir.nl/fhir/NamingSystem/rsin"
+// * group[=].rule[=].rule[=].rule[=].rule[+].name = "rsinValue"
+// * group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "rsin"
+// * group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "rsinId"
+// * group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+// * group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "value"
+// * group[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+// * group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueId = "rsin"
+
+// Nested: hoofdvestiging → address + telecom
+* group[=].rule[=].rule[+].name = "hoofdvestiging"
+* group[=].rule[=].rule[=].source[+].context = "emb"
+* group[=].rule[=].rule[=].source[=].element = "hoofdvestiging"
+* group[=].rule[=].rule[=].source[=].variable = "hv"
+// hoofdvestiging.adressen → address (via dependent group)
+* group[=].rule[=].rule[=].rule[+].name = "adressen"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "hv"
+* group[=].rule[=].rule[=].rule[=].source[=].element = "adressen"
+* group[=].rule[=].rule[=].rule[=].source[=].variable = "adres"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "address"
+* group[=].rule[=].rule[=].rule[=].target[=].variable = "addr"
+* group[=].rule[=].rule[=].rule[=].dependent[+].name = "KvkAdresToAddress"
+* group[=].rule[=].rule[=].rule[=].dependent[=].variable[+] = "adres"
+* group[=].rule[=].rule[=].rule[=].dependent[=].variable[+] = "addr"
+// hoofdvestiging.websites → telecom (via dependent group)
+* group[=].rule[=].rule[=].rule[+].name = "websites"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "hv"
+* group[=].rule[=].rule[=].rule[=].source[=].element = "websites"
+* group[=].rule[=].rule[=].rule[=].source[=].variable = "web"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "telecom"
+* group[=].rule[=].rule[=].rule[=].target[=].variable = "tel"
+* group[=].rule[=].rule[=].rule[=].dependent[+].name = "KvkWebsiteToContactPoint"
+* group[=].rule[=].rule[=].rule[=].dependent[=].variable[+] = "web"
+* group[=].rule[=].rule[=].rule[=].dependent[=].variable[+] = "tel"
+
+// ── Group 1: Handelsnaam → Organization.alias ───────────────────────────────
+* group[+].name = "KvkHandelsnaamToAlias"
+* group[=].typeMode = #none
+* group[=].input[+].name = "src"
+* group[=].input[=].mode = #source
+* group[=].input[+].name = "tgt"
+* group[=].input[=].type = "Organization"
+* group[=].input[=].mode = #target
+
+* group[=].rule[+].name = "naam"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "naam"
+* group[=].rule[=].source[=].variable = "naam"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "alias"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "naam"
+
+// ── Group 2: SBI Activiteit → CodeableConcept ───────────────────────────────
+* group[+].name = "KvkSBIToCodeableConcept"
+* group[=].typeMode = #none
+* group[=].input[+].name = "src"
+* group[=].input[=].mode = #source
+* group[=].input[+].name = "tgt"
+* group[=].input[=].type = "CodeableConcept"
+* group[=].input[=].mode = #target
+
+// Create coding element and populate it
+* group[=].rule[+].name = "sbiCoding"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "coding"
+* group[=].rule[=].target[=].variable = "coding"
+// Set system
+* group[=].rule[=].rule[+].name = "sbiSystem"
+* group[=].rule[=].rule[=].source[+].context = "src"
+* group[=].rule[=].rule[=].target[+].context = "coding"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "system"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://minvws.github.io/generiekefuncties-docs/CodeSystem/nl-gf-sbi-2025-cs"
+// Map sbiCode → coding.code
+* group[=].rule[=].rule[+].name = "sbiCode"
+* group[=].rule[=].rule[=].source[+].context = "src"
+* group[=].rule[=].rule[=].source[=].element = "sbiCode"
+* group[=].rule[=].rule[=].source[=].variable = "code"
+* group[=].rule[=].rule[=].target[+].context = "coding"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "code"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueId = "code"
+// Map sbiOmschrijving → coding.display
+* group[=].rule[=].rule[+].name = "sbiDisplay"
+* group[=].rule[=].rule[=].source[+].context = "src"
+* group[=].rule[=].rule[=].source[=].element = "sbiOmschrijving"
+* group[=].rule[=].rule[=].source[=].variable = "omschr"
+* group[=].rule[=].rule[=].target[+].context = "coding"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "display"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueId = "omschr"
+
+// ── Group 3: KVK Adres → FHIR Address ──────────────────────────────────────
+* group[+].name = "KvkAdresToAddress"
+* group[=].typeMode = #none
+* group[=].input[+].name = "src"
+* group[=].input[=].mode = #source
+* group[=].input[+].name = "tgt"
+* group[=].input[=].type = "Address"
+* group[=].input[=].mode = #target
+
+// volledigAdres → text
+* group[=].rule[+].name = "volledigAdres"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "volledigAdres"
+* group[=].rule[=].source[=].variable = "volledigAdres"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "text"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "volledigAdres"
+
+// straatnaam → line + iso21090-ADXP-streetName extension
+* group[=].rule[+].name = "straatnaam"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "straatnaam"
+* group[=].rule[=].source[=].variable = "straat"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "line"
+* group[=].rule[=].target[=].variable = "addrLine"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "straat"
+// nested: iso21090-ADXP-streetName extension
+* group[=].rule[=].rule[+].name = "streetNameExt"
+* group[=].rule[=].rule[=].source[+].context = "straat"
+* group[=].rule[=].rule[=].target[+].context = "addrLine"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "extension"
+* group[=].rule[=].rule[=].target[=].variable = "ext"
+* group[=].rule[=].rule[=].rule[+].name = "streetNameExtUrl"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "straat"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "ext"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "url"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName"
+* group[=].rule[=].rule[=].rule[+].name = "streetNameExtValue"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "straat"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "ext"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "valueString"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueId = "straat"
+
+// huisnummer → line + iso21090-ADXP-houseNumber extension
+* group[=].rule[+].name = "huisnummer"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "huisnummer"
+* group[=].rule[=].source[=].variable = "huisnr"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "line"
+* group[=].rule[=].target[=].variable = "addrLine2"
+* group[=].rule[=].target[=].transform = #cast
+* group[=].rule[=].target[=].parameter[+].valueId = "huisnr"
+// nested: iso21090-ADXP-houseNumber extension
+* group[=].rule[=].rule[+].name = "houseNumberExt"
+* group[=].rule[=].rule[=].source[+].context = "huisnr"
+* group[=].rule[=].rule[=].target[+].context = "addrLine2"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "extension"
+* group[=].rule[=].rule[=].target[=].variable = "ext"
+* group[=].rule[=].rule[=].rule[+].name = "houseNumberExtUrl"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "huisnr"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "ext"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "url"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber"
+* group[=].rule[=].rule[=].rule[+].name = "houseNumberExtValue"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "huisnr"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "ext"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "valueString"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #cast
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueId = "huisnr"
+
+// huisletter → line + iso21090-ADXP-buildingNumberSuffix extension
+* group[=].rule[+].name = "huisletter"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "huisletter"
+* group[=].rule[=].source[=].variable = "huisltr"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "line"
+* group[=].rule[=].target[=].variable = "addrLine3"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "huisltr"
+// nested: iso21090-ADXP-buildingNumberSuffix extension
+* group[=].rule[=].rule[+].name = "houseLetterExt"
+* group[=].rule[=].rule[=].source[+].context = "huisltr"
+* group[=].rule[=].rule[=].target[+].context = "addrLine3"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "extension"
+* group[=].rule[=].rule[=].target[=].variable = "ext"
+* group[=].rule[=].rule[=].rule[+].name = "houseLetterExtUrl"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "huisltr"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "ext"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "url"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-buildingNumberSuffix"
+* group[=].rule[=].rule[=].rule[+].name = "houseLetterExtValue"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "huisltr"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "ext"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "valueString"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueId = "huisltr"
+
+// huisnummerToevoeging → line + iso21090-ADXP-buildingNumberSuffix extension
+* group[=].rule[+].name = "huisnummerToevoeging"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "huisnummerToevoeging"
+* group[=].rule[=].source[=].variable = "huisnrToev"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "line"
+* group[=].rule[=].target[=].variable = "addrLine4"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "huisnrToev"
+// nested: iso21090-ADXP-buildingNumberSuffix extension
+* group[=].rule[=].rule[+].name = "houseNumberAdditionExt"
+* group[=].rule[=].rule[=].source[+].context = "huisnrToev"
+* group[=].rule[=].rule[=].target[+].context = "addrLine4"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "extension"
+* group[=].rule[=].rule[=].target[=].variable = "ext"
+* group[=].rule[=].rule[=].rule[+].name = "houseNumberAdditionExtUrl"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "huisnrToev"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "ext"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "url"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-buildingNumberSuffix"
+* group[=].rule[=].rule[=].rule[+].name = "houseNumberAdditionExtValue"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "huisnrToev"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "ext"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "valueString"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueId = "huisnrToev"
+
+// postcode → postalCode
+* group[=].rule[+].name = "postcode"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "postcode"
+* group[=].rule[=].source[=].variable = "pc"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "postalCode"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "pc"
+
+// plaats → city
+* group[=].rule[+].name = "plaats"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "plaats"
+* group[=].rule[=].source[=].variable = "plaats"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "city"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "plaats"
+
+// land → country
+* group[=].rule[+].name = "land"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "land"
+* group[=].rule[=].source[=].variable = "land"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "country"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "land"
+
+// use = "work" (organization addresses are always work addresses)
+* group[=].rule[+].name = "setUse"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "use"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueString = "work"
+
+// ── Group 4: Website string → FHIR ContactPoint ────────────────────────────
+* group[+].name = "KvkWebsiteToContactPoint"
+* group[=].typeMode = #none
+* group[=].input[+].name = "src"
+* group[=].input[=].mode = #source
+* group[=].input[+].name = "tgt"
+* group[=].input[=].type = "ContactPoint"
+* group[=].input[=].mode = #target
+
+// system = url
+* group[=].rule[+].name = "setSystem"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "system"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueString = "url"
+
+// value = website URL
+* group[=].rule[+].name = "setValue"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].variable = "url"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "value"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "url"
+
+// use = work
+* group[=].rule[+].name = "setUse"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "use"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueString = "work"
+
+// ============================================================================
+// Logical Model: KVK Vestigingsprofiel (source structure for StructureMap)
+// ============================================================================
+
+Logical: KvkVestigingsprofiel
+Id: kvk-vestigingsprofiel
+Title: "KVK Vestigingsprofiel"
+Description: "Logical model representing the KVK (Kamer van Koophandel) Vestigingsprofiel API response structure as defined in the KVK API v1.4.0."
+* vestigingsnummer 0..1 string "Vestigingsnummer: uniek nummer dat bestaat uit 12 cijfers"
+* kvkNummer 0..1 string "Nederlands Kamer van Koophandel nummer: bestaat uit 8 cijfers"
+* rsin 0..1 string "Rechtspersonen Samenwerkingsverbanden Informatie Nummer"
+* indNonMailing 0..1 string "Indicatie geen ongevraagde reclame per post of verkoop aan de deur"
+* formeleRegistratiedatum 0..1 string "Registratiedatum onderneming in HR"
+* materieleRegistratie 0..1 BackboneElement "Materiële registratie datums"
+  * datumAanvang 0..1 string "Startdatum vestiging"
+  * datumEinde 0..1 string "Einddatum vestiging"
+* statutaireNaam 0..1 string "De naam van de vestiging wanneer er statuten geregistreerd zijn"
+* eersteHandelsnaam 0..1 string "De naam waaronder een onderneming of vestiging handelt"
+* indHoofdvestiging 0..1 string "Hoofdvestiging (Ja/Nee)"
+* indCommercieleVestiging 0..1 string "Commerciële vestiging (Ja/Nee)"
+* voltijdWerkzamePersonen 0..1 integer "Aantal voltijd werkzame personen"
+* totaalWerkzamePersonen 0..1 integer "Totaal aantal werkzame personen"
+* deeltijdWerkzamePersonen 0..1 integer "Aantal deeltijd werkzame personen"
+* handelsnamen 0..* BackboneElement "Alle namen waaronder een vestiging handelt (op volgorde van registreren)"
+  * naam 0..1 string "Handelsnaam"
+  * volgorde 0..1 integer "Volgorde van registreren"
+* adressen 0..* BackboneElement "Adressen van de vestiging"
+  * type 0..1 string "Correspondentieadres en/of bezoekadres"
+  * indAfgeschermd 0..1 string "Indicatie of het adres is afgeschermd"
+  * volledigAdres 0..1 string "Volledig adres"
+  * straatnaam 0..1 string "Straatnaam"
+  * huisnummer 0..1 integer "Huisnummer"
+  * huisletter 0..1 string "Huisletter"
+  * huisnummerToevoeging 0..1 string "Huisnummer toevoeging"
+  * toevoegingAdres 0..1 string "Toevoeging adres"
+  * postcode 0..1 string "Postcode"
+  * postbusnummer 0..1 integer "Postbusnummer"
+  * plaats 0..1 string "Plaats"
+  * straatHuisnummer 0..1 string "Straat en huisnummer"
+  * postcodeWoonplaats 0..1 string "Postcode en woonplaats"
+  * regio 0..1 string "Regio"
+  * land 0..1 string "Land"
+  * geoData 0..1 BackboneElement "BAG geoData"
+    * addresseerbaarObjectId 0..1 string "Unieke BAG id"
+    * nummerAanduidingId 0..1 string "Unieke BAG nummeraanduiding id"
+    * gpsLatitude 0..1 decimal "Lengtegraad"
+    * gpsLongitude 0..1 decimal "Breedtegraad"
+    * rijksdriehoekX 0..1 decimal "Rijksdriehoek X-coördinaat"
+    * rijksdriehoekY 0..1 decimal "Rijksdriehoek Y-coördinaat"
+    * rijksdriehoekZ 0..1 decimal "Rijksdriehoek Z-coördinaat"
+* websites 0..* string "Websites"
+* sbiActiviteiten 0..* BackboneElement "SBI activiteiten conform SBI 2008"
+  * sbiCode 0..1 string "SBI code"
+  * sbiOmschrijving 0..1 string "SBI omschrijving"
+  * indHoofdactiviteit 0..1 string "Indicatie hoofdactiviteit"
+
+// ============================================================================
+// StructureMap: KVK Vestigingsprofiel → FHIR Location
+//
+// Mapping summary:
+//   vestigingsnummer                → Location.identifier (system: kvk-vestigingsnummer)
+//   kvkNummer                       → Location.identifier (system: kvk)
+//   eersteHandelsnaam               → Location.name
+//   statutaireNaam                  → Location.alias
+//   handelsnamen[].naam             → Location.alias
+//   adressen[]                      → Location.address
+//   adressen[].geoData              → Location.position (latitude/longitude)
+//   websites[]                      → Location.telecom (system: url)
+//   indHoofdvestiging/materieleReg  → Location.status (active/inactive)
+// ============================================================================
+
+Instance: KvkVestigingsprofielToLocation
+InstanceOf: StructureMap
+Usage: #definition
+Title: "KVK Vestigingsprofiel naar FHIR Location"
+Description: "StructureMap die een KVK Vestigingsprofiel API response transformeert naar een FHIR Location resource."
+* url = "http://minvws.github.io/generiekefuncties-docs/StructureMap/KvkVestigingsprofielToLocation"
+* name = "KvkVestigingsprofielToLocation"
+* status = #draft
+* structure[+].url = "http://minvws.github.io/generiekefuncties-docs/StructureDefinition/kvk-vestigingsprofiel"
+* structure[=].mode = #source
+* structure[=].alias = "KvkVestigingsprofiel"
+* structure[+].url = Canonical(NlGfLocation)
+* structure[=].mode = #target
+* structure[=].alias = "NlGfLocation"
+
+// ── Group 0: Main mapping KvkVestigingsprofiel → Location ───────────────────
+* group[+].name = "KvkVestigingsprofielToLocation"
+* group[=].typeMode = #none
+* group[=].input[+].name = "src"
+* group[=].input[=].type = "KvkVestigingsprofiel"
+* group[=].input[=].mode = #source
+* group[=].input[+].name = "tgt"
+* group[=].input[=].type = "Location"
+* group[=].input[=].mode = #target
+
+// Rule: vestigingsnummer → identifier (system: http://fhir.nl/fhir/NamingSystem/kvk-vestigingsnummer)
+* group[=].rule[+].name = "vestigingsnummer"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "vestigingsnummer"
+* group[=].rule[=].source[=].variable = "vestNr"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "identifier"
+* group[=].rule[=].target[=].variable = "vestId"
+* group[=].rule[=].rule[+].name = "vestSystem"
+* group[=].rule[=].rule[=].source[+].context = "vestNr"
+* group[=].rule[=].rule[=].target[+].context = "vestId"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "system"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://fhir.nl/fhir/NamingSystem/kvk-vestigingsnummer"
+* group[=].rule[=].rule[+].name = "vestValue"
+* group[=].rule[=].rule[=].source[+].context = "vestNr"
+* group[=].rule[=].rule[=].target[+].context = "vestId"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "value"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueId = "vestNr"
+
+// Rule: kvkNummer → managingOrganization (Reference by identifier, system: kvk)
+* group[=].rule[+].name = "kvkNummer"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "kvkNummer"
+* group[=].rule[=].source[=].variable = "kvkNum"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "managingOrganization"
+* group[=].rule[=].target[=].variable = "orgRef"
+* group[=].rule[=].rule[+].name = "orgRefIdentifier"
+* group[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].target[+].context = "orgRef"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "identifier"
+* group[=].rule[=].rule[=].target[=].variable = "orgId"
+* group[=].rule[=].rule[=].rule[+].name = "orgIdSystem"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "orgId"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "system"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://fhir.nl/fhir/NamingSystem/kvk"
+* group[=].rule[=].rule[=].rule[+].name = "orgIdValue"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "orgId"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "value"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueId = "kvkNum"
+* group[=].rule[=].rule[+].name = "orgRefType"
+* group[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].target[+].context = "orgRef"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "type"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueString = "Organization"
+
+// Rule: eersteHandelsnaam → name
+* group[=].rule[+].name = "eersteHandelsnaam"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "eersteHandelsnaam"
+* group[=].rule[=].source[=].variable = "naam"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "name"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "naam"
+
+// Rule: status = active
+* group[=].rule[+].name = "setStatus"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "status"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueString = "active"
+
+// Rule: mode = instance (this is a specific physical location)
+* group[=].rule[+].name = "setMode"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "mode"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueString = "instance"
+
+// Rule: statutaireNaam → alias
+* group[=].rule[+].name = "statutaireNaam"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "statutaireNaam"
+* group[=].rule[=].source[=].variable = "statNaam"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "alias"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "statNaam"
+
+// Rule: handelsnamen → alias (via dependent group)
+* group[=].rule[+].name = "handelsnamen"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "handelsnamen"
+* group[=].rule[=].source[=].variable = "hn"
+* group[=].rule[=].dependent[+].name = "KvkVestHandelsnaamToAlias"
+* group[=].rule[=].dependent[=].variable[+] = "hn"
+* group[=].rule[=].dependent[=].variable[+] = "tgt"
+
+// Rule: adressen → address + position (via dependent group)
+* group[=].rule[+].name = "adressen"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "adressen"
+* group[=].rule[=].source[=].variable = "adres"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "address"
+* group[=].rule[=].target[=].variable = "addr"
+* group[=].rule[=].dependent[+].name = "KvkVestAdresToAddress"
+* group[=].rule[=].dependent[=].variable[+] = "adres"
+* group[=].rule[=].dependent[=].variable[+] = "addr"
+
+// Rule: adressen.geoData → position (first address with geoData wins)
+* group[=].rule[+].name = "geoData"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "adressen"
+* group[=].rule[=].source[=].variable = "adres"
+* group[=].rule[=].rule[+].name = "geoDataToPosition"
+* group[=].rule[=].rule[=].source[+].context = "adres"
+* group[=].rule[=].rule[=].source[=].element = "geoData"
+* group[=].rule[=].rule[=].source[=].variable = "geo"
+* group[=].rule[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "position"
+* group[=].rule[=].rule[=].target[=].variable = "pos"
+* group[=].rule[=].rule[=].dependent[+].name = "KvkGeoDataToPosition"
+* group[=].rule[=].rule[=].dependent[=].variable[+] = "geo"
+* group[=].rule[=].rule[=].dependent[=].variable[+] = "pos"
+
+// Rule: websites → telecom (via dependent group)
+* group[=].rule[+].name = "websites"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "websites"
+* group[=].rule[=].source[=].variable = "web"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "telecom"
+* group[=].rule[=].target[=].variable = "tel"
+* group[=].rule[=].dependent[+].name = "KvkVestWebsiteToContactPoint"
+* group[=].rule[=].dependent[=].variable[+] = "web"
+* group[=].rule[=].dependent[=].variable[+] = "tel"
+
+// ── Group 1: Handelsnaam → Location.alias ───────────────────────────────────
+* group[+].name = "KvkVestHandelsnaamToAlias"
+* group[=].typeMode = #none
+* group[=].input[+].name = "src"
+* group[=].input[=].mode = #source
+* group[=].input[+].name = "tgt"
+* group[=].input[=].type = "Location"
+* group[=].input[=].mode = #target
+
+* group[=].rule[+].name = "naam"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "naam"
+* group[=].rule[=].source[=].variable = "naam"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "alias"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "naam"
+
+// ── Group 2: KVK Adres → FHIR Address (vestigingsprofiel variant with full fields) ─
+* group[+].name = "KvkVestAdresToAddress"
+* group[=].typeMode = #none
+* group[=].input[+].name = "src"
+* group[=].input[=].mode = #source
+* group[=].input[+].name = "tgt"
+* group[=].input[=].type = "Address"
+* group[=].input[=].mode = #target
+
+// volledigAdres → text
+* group[=].rule[+].name = "volledigAdres"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "volledigAdres"
+* group[=].rule[=].source[=].variable = "volledigAdres"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "text"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "volledigAdres"
+
+// straatnaam → line + iso21090-ADXP-streetName extension
+* group[=].rule[+].name = "straatnaam"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "straatnaam"
+* group[=].rule[=].source[=].variable = "straat"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "line"
+* group[=].rule[=].target[=].variable = "addrLine"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "straat"
+// nested: iso21090-ADXP-streetName extension
+* group[=].rule[=].rule[+].name = "streetNameExt"
+* group[=].rule[=].rule[=].source[+].context = "straat"
+* group[=].rule[=].rule[=].target[+].context = "addrLine"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "extension"
+* group[=].rule[=].rule[=].target[=].variable = "ext"
+* group[=].rule[=].rule[=].rule[+].name = "streetNameExtUrl"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "straat"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "ext"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "url"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName"
+* group[=].rule[=].rule[=].rule[+].name = "streetNameExtValue"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "straat"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "ext"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "valueString"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueId = "straat"
+
+// huisnummer → line + iso21090-ADXP-houseNumber extension
+* group[=].rule[+].name = "huisnummer"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "huisnummer"
+* group[=].rule[=].source[=].variable = "huisnr"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "line"
+* group[=].rule[=].target[=].variable = "addrLine2"
+* group[=].rule[=].target[=].transform = #cast
+* group[=].rule[=].target[=].parameter[+].valueId = "huisnr"
+// nested: iso21090-ADXP-houseNumber extension
+* group[=].rule[=].rule[+].name = "houseNumberExt"
+* group[=].rule[=].rule[=].source[+].context = "huisnr"
+* group[=].rule[=].rule[=].target[+].context = "addrLine2"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "extension"
+* group[=].rule[=].rule[=].target[=].variable = "ext"
+* group[=].rule[=].rule[=].rule[+].name = "houseNumberExtUrl"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "huisnr"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "ext"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "url"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber"
+* group[=].rule[=].rule[=].rule[+].name = "houseNumberExtValue"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "huisnr"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "ext"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "valueString"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #cast
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueId = "huisnr"
+
+// huisletter → line + iso21090-ADXP-buildingNumberSuffix extension
+* group[=].rule[+].name = "huisletter"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "huisletter"
+* group[=].rule[=].source[=].variable = "huisltr"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "line"
+* group[=].rule[=].target[=].variable = "addrLine3"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "huisltr"
+// nested: iso21090-ADXP-buildingNumberSuffix extension
+* group[=].rule[=].rule[+].name = "houseLetterExt"
+* group[=].rule[=].rule[=].source[+].context = "huisltr"
+* group[=].rule[=].rule[=].target[+].context = "addrLine3"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "extension"
+* group[=].rule[=].rule[=].target[=].variable = "ext"
+* group[=].rule[=].rule[=].rule[+].name = "houseLetterExtUrl"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "huisltr"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "ext"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "url"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-buildingNumberSuffix"
+* group[=].rule[=].rule[=].rule[+].name = "houseLetterExtValue"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "huisltr"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "ext"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "valueString"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueId = "huisltr"
+
+// huisnummerToevoeging → line + iso21090-ADXP-buildingNumberSuffix extension
+* group[=].rule[+].name = "huisnummerToevoeging"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "huisnummerToevoeging"
+* group[=].rule[=].source[=].variable = "huisnrToev"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "line"
+* group[=].rule[=].target[=].variable = "addrLine4"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "huisnrToev"
+// nested: iso21090-ADXP-buildingNumberSuffix extension
+* group[=].rule[=].rule[+].name = "houseNumberAdditionExt"
+* group[=].rule[=].rule[=].source[+].context = "huisnrToev"
+* group[=].rule[=].rule[=].target[+].context = "addrLine4"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "extension"
+* group[=].rule[=].rule[=].target[=].variable = "ext"
+* group[=].rule[=].rule[=].rule[+].name = "houseNumberAdditionExtUrl"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "huisnrToev"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "ext"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "url"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-buildingNumberSuffix"
+* group[=].rule[=].rule[=].rule[+].name = "houseNumberAdditionExtValue"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "huisnrToev"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "ext"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "valueString"
+* group[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueId = "huisnrToev"
+
+// postcode → postalCode
+* group[=].rule[+].name = "postcode"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "postcode"
+* group[=].rule[=].source[=].variable = "pc"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "postalCode"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "pc"
+
+// plaats → city
+* group[=].rule[+].name = "plaats"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "plaats"
+* group[=].rule[=].source[=].variable = "plaats"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "city"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "plaats"
+
+// regio → district
+* group[=].rule[+].name = "regio"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "regio"
+* group[=].rule[=].source[=].variable = "regio"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "district"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "regio"
+
+// land → country
+* group[=].rule[+].name = "land"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "land"
+* group[=].rule[=].source[=].variable = "land"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "country"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "land"
+
+// use = work
+* group[=].rule[+].name = "setUse"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "use"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueString = "work"
+
+// ── Group 3: GeoData → Location.position ────────────────────────────────────
+* group[+].name = "KvkGeoDataToPosition"
+* group[=].typeMode = #none
+* group[=].input[+].name = "src"
+* group[=].input[=].mode = #source
+* group[=].input[+].name = "tgt"
+* group[=].input[=].type = "Location.position"
+* group[=].input[=].mode = #target
+
+// gpsLatitude → latitude
+* group[=].rule[+].name = "latitude"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "gpsLatitude"
+* group[=].rule[=].source[=].variable = "lat"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "latitude"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "lat"
+
+// gpsLongitude → longitude
+* group[=].rule[+].name = "longitude"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "gpsLongitude"
+* group[=].rule[=].source[=].variable = "lon"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "longitude"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "lon"
+
+// ── Group 4: Website string → FHIR ContactPoint (vestigingsprofiel) ─────────
+* group[+].name = "KvkVestWebsiteToContactPoint"
+* group[=].typeMode = #none
+* group[=].input[+].name = "src"
+* group[=].input[=].mode = #source
+* group[=].input[+].name = "tgt"
+* group[=].input[=].type = "ContactPoint"
+* group[=].input[=].mode = #target
+
+// system = url
+* group[=].rule[+].name = "setSystem"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "system"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueString = "url"
+
+// value = website URL
+* group[=].rule[+].name = "setValue"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].variable = "url"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "value"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueId = "url"
+
+// use = work
+* group[=].rule[+].name = "setUse"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "use"
+* group[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].target[=].parameter[+].valueString = "work"

--- a/input/fsh/structuremaps.fsh
+++ b/input/fsh/structuremaps.fsh
@@ -7,6 +7,7 @@ Id: kvk-basisprofiel
 Title: "KVK Basisprofiel"
 Description: "Logical model representing the KVK (Kamer van Koophandel) Basisprofiel API response structure as defined in the KVK API v1.4.0."
 * kvkNummer 0..1 string "Nederlands Kamer van Koophandel nummer: bestaat uit 8 cijfers"
+* uraNummer 0..* string "URA nummer uit het LRZa"
 * indNonMailing 0..1 string "Indicatie geen ongevraagde reclame per post of verkoop aan de deur"
 * naam 0..1 string "Naam onder Maatschappelijke Activiteit"
 * formeleRegistratiedatum 0..1 string "Registratiedatum onderneming in het Handelsregister"
@@ -149,53 +150,85 @@ Description: "StructureMap die een KVK Basisprofiel API response transformeert n
 * group[=].rule[=].rule[=].target[=].element = "value"
 * group[=].rule[=].rule[=].target[=].transform = #copy
 * group[=].rule[=].rule[=].target[=].parameter[+].valueId = "kvkNum"
-* group[=].rule[=].rule[+].name = "kvkAssigner"
-* group[=].rule[=].rule[=].source[+].context = "kvkNum"
-* group[=].rule[=].rule[=].target[+].context = "kvkId"
+
+
+// Rule: uraNummer → identifier (system: http://fhir.nl/fhir/NamingSystem/ura)
+* group[=].rule[+].name = "uraNummer"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "uraNummer"
+* group[=].rule[=].source[=].variable = "uraNum"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "identifier"
+* group[=].rule[=].target[=].variable = "uraId"
+* group[=].rule[=].rule[+].name = "uraUse"
+* group[=].rule[=].rule[=].source[+].context = "uraNum"
+* group[=].rule[=].rule[=].target[+].context = "uraId"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "use"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueString = "official"
+* group[=].rule[=].rule[+].name = "uraSystem"
+* group[=].rule[=].rule[=].source[+].context = "uraNum"
+* group[=].rule[=].rule[=].target[+].context = "uraId"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "system"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://fhir.nl/fhir/NamingSystem/ura"
+* group[=].rule[=].rule[+].name = "uraValue"
+* group[=].rule[=].rule[=].source[+].context = "uraNum"
+* group[=].rule[=].rule[=].target[+].context = "uraId"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "value"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueId = "uraNum"
+* group[=].rule[=].rule[+].name = "uraAssigner"
+* group[=].rule[=].rule[=].source[+].context = "uraNum"
+* group[=].rule[=].rule[=].target[+].context = "uraId"
 * group[=].rule[=].rule[=].target[=].contextType = #variable
 * group[=].rule[=].rule[=].target[=].element = "assigner"
 * group[=].rule[=].rule[=].target[=].variable = "assignerRef"
 * group[=].rule[=].rule[=].rule[+].name = "assignerIdentifier"
-* group[=].rule[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "uraNum"
 * group[=].rule[=].rule[=].rule[=].target[+].context = "assignerRef"
 * group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
 * group[=].rule[=].rule[=].rule[=].target[=].element = "identifier"
 * group[=].rule[=].rule[=].rule[=].target[=].variable = "assignerId"
 * group[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdSystem"
-* group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "uraNum"
 * group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerId"
 * group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
 * group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "system"
 * group[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
-* group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://fhir.nl/fhir/NamingSystem/kvk"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://fhir.nl/fhir/NamingSystem/ura"
 * group[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdValue"
-* group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "uraNum"
 * group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerId"
 * group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
 * group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "value"
 * group[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
-* group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "50000535"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "00000001"
 * group[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdType"
-* group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "uraNum"
 * group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerId"
 * group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
 * group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "type"
 * group[=].rule[=].rule[=].rule[=].rule[=].target[=].variable = "assignerIdType"
 * group[=].rule[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdTypeCoding"
-* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "uraNum"
 * group[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerIdType"
 * group[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
 * group[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "coding"
 * group[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].variable = "assignerIdTypeCoding"
 * group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdTypeCodingSystem"
-* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "uraNum"
 * group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerIdTypeCoding"
 * group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
 * group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "system"
 * group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
 * group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://terminology.hl7.org/CodeSystem/provenance-participant-type"
 * group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdTypeCodingCode"
-* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "uraNum"
 * group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerIdTypeCoding"
 * group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
 * group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "code"
@@ -848,6 +881,14 @@ Description: "StructureMap die een KVK Vestigingsprofiel API response transforme
 * group[=].rule[=].rule[=].target[=].element = "type"
 * group[=].rule[=].rule[=].target[=].transform = #copy
 * group[=].rule[=].rule[=].target[=].parameter[+].valueString = "Organization"
+* group[=].rule[=].rule[+].name = "orgRefReference"
+* group[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].target[+].context = "orgRef"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "reference"
+* group[=].rule[=].rule[=].target[=].transform = #append
+* group[=].rule[=].rule[=].target[=].parameter[+].valueString = "Organization/"
+* group[=].rule[=].rule[=].target[=].parameter[+].valueId = "kvkNum"
 
 // Rule: eersteHandelsnaam → name
 * group[=].rule[+].name = "eersteHandelsnaam"

--- a/input/fsh/structuremaps.fsh
+++ b/input/fsh/structuremaps.fsh
@@ -810,14 +810,14 @@ Description: "StructureMap die een KVK Vestigingsprofiel API response transforme
 * group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
 * group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "system"
 * group[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
-* group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://fhir.nl/fhir/NamingSystem/kvk"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://fhir.nl/fhir/NamingSystem/ura"
 * group[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdValue"
 * group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "vestNr"
 * group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerId"
 * group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
 * group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "value"
 * group[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
-* group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "50000535"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "00000001"
 * group[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdType"
 * group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "vestNr"
 * group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerId"

--- a/input/fsh/structuremaps.fsh
+++ b/input/fsh/structuremaps.fsh
@@ -83,6 +83,7 @@ InstanceOf: StructureMap
 Usage: #definition
 Title: "KVK Basisprofiel naar FHIR Organization"
 Description: "StructureMap die een KVK Basisprofiel API response transformeert naar een FHIR Organization resource."
+* id = "KvkBasisprofielToOrganization"
 * url = "http://minvws.github.io/generiekefuncties-docs/StructureMap/KvkBasisprofielToOrganization"
 * name = "KvkBasisprofielToOrganization"
 * status = #draft
@@ -103,6 +104,21 @@ Description: "StructureMap die een KVK Basisprofiel API response transformeert n
 * group[=].input[=].type = "Organization"
 * group[=].input[=].mode = #target
 
+// Rule: set meta.profile to NlGfOrganization
+* group[=].rule[+].name = "setProfile"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "meta"
+* group[=].rule[=].target[=].variable = "meta"
+* group[=].rule[=].rule[+].name = "setProfileUrl"
+* group[=].rule[=].rule[=].source[+].context = "src"
+* group[=].rule[=].rule[=].target[+].context = "meta"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "profile"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://minvws.github.io/generiekefuncties-docs/StructureDefinition/nl-gf-organization"
+
 // Rule: kvkNummer → identifier (system: http://fhir.nl/fhir/NamingSystem/kvk)
 * group[=].rule[+].name = "kvkNummer"
 * group[=].rule[=].source[+].context = "src"
@@ -112,6 +128,13 @@ Description: "StructureMap die een KVK Basisprofiel API response transformeert n
 * group[=].rule[=].target[=].contextType = #variable
 * group[=].rule[=].target[=].element = "identifier"
 * group[=].rule[=].target[=].variable = "kvkId"
+* group[=].rule[=].rule[+].name = "kvkUse"
+* group[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].target[+].context = "kvkId"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "use"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueString = "official"
 * group[=].rule[=].rule[+].name = "kvkSystem"
 * group[=].rule[=].rule[=].source[+].context = "kvkNum"
 * group[=].rule[=].rule[=].target[+].context = "kvkId"
@@ -126,6 +149,58 @@ Description: "StructureMap die een KVK Basisprofiel API response transformeert n
 * group[=].rule[=].rule[=].target[=].element = "value"
 * group[=].rule[=].rule[=].target[=].transform = #copy
 * group[=].rule[=].rule[=].target[=].parameter[+].valueId = "kvkNum"
+* group[=].rule[=].rule[+].name = "kvkAssigner"
+* group[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].target[+].context = "kvkId"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "assigner"
+* group[=].rule[=].rule[=].target[=].variable = "assignerRef"
+* group[=].rule[=].rule[=].rule[+].name = "assignerIdentifier"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "assignerRef"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "identifier"
+* group[=].rule[=].rule[=].rule[=].target[=].variable = "assignerId"
+* group[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdSystem"
+* group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerId"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "system"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://fhir.nl/fhir/NamingSystem/kvk"
+* group[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdValue"
+* group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerId"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "value"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "50000535"
+* group[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdType"
+* group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerId"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "type"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].variable = "assignerIdType"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdTypeCoding"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerIdType"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "coding"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].variable = "assignerIdTypeCoding"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdTypeCodingSystem"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerIdTypeCoding"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "system"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://terminology.hl7.org/CodeSystem/provenance-participant-type"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdTypeCodingCode"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "kvkNum"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerIdTypeCoding"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "code"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "author"
 
 // Rule: naam → name
 * group[=].rule[+].name = "naam"
@@ -186,33 +261,33 @@ Description: "StructureMap die een KVK Basisprofiel API response transformeert n
 * group[=].rule[=].source[=].element = "embedded"
 * group[=].rule[=].source[=].variable = "emb"
 
-// // Nested: eigenaar.rsin → identifier (system: rsin)
-// * group[=].rule[=].rule[+].name = "eigenaar"
-// * group[=].rule[=].rule[=].source[+].context = "emb"
-// * group[=].rule[=].rule[=].source[=].element = "eigenaar"
-// * group[=].rule[=].rule[=].source[=].variable = "eig"
-// * group[=].rule[=].rule[=].rule[+].name = "rsin"
-// * group[=].rule[=].rule[=].rule[=].source[+].context = "eig"
-// * group[=].rule[=].rule[=].rule[=].source[=].element = "rsin"
-// * group[=].rule[=].rule[=].rule[=].source[=].variable = "rsin"
-// * group[=].rule[=].rule[=].rule[=].target[+].context = "tgt"
-// * group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
-// * group[=].rule[=].rule[=].rule[=].target[=].element = "identifier"
-// * group[=].rule[=].rule[=].rule[=].target[=].variable = "rsinId"
-// * group[=].rule[=].rule[=].rule[=].rule[+].name = "rsinSystem"
-// * group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "rsin"
-// * group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "rsinId"
-// * group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
-// * group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "system"
-// * group[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
-// * group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://fhir.nl/fhir/NamingSystem/rsin"
-// * group[=].rule[=].rule[=].rule[=].rule[+].name = "rsinValue"
-// * group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "rsin"
-// * group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "rsinId"
-// * group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
-// * group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "value"
-// * group[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
-// * group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueId = "rsin"
+// Nested: eigenaar.rsin → identifier (system: rsin)
+* group[=].rule[=].rule[+].name = "eigenaar"
+* group[=].rule[=].rule[=].source[+].context = "emb"
+* group[=].rule[=].rule[=].source[=].element = "eigenaar"
+* group[=].rule[=].rule[=].source[=].variable = "eig"
+* group[=].rule[=].rule[=].rule[+].name = "rsin"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "eig"
+* group[=].rule[=].rule[=].rule[=].source[=].element = "rsin"
+* group[=].rule[=].rule[=].rule[=].source[=].variable = "rsin"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "identifier"
+* group[=].rule[=].rule[=].rule[=].target[=].variable = "rsinId"
+* group[=].rule[=].rule[=].rule[=].rule[+].name = "rsinSystem"
+* group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "rsin"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "rsinId"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "system"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://fhir.nl/fhir/NamingSystem/rsin"
+* group[=].rule[=].rule[=].rule[=].rule[+].name = "rsinValue"
+* group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "rsin"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "rsinId"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "value"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueId = "rsin"
 
 // Nested: hoofdvestiging → address + telecom
 * group[=].rule[=].rule[+].name = "hoofdvestiging"
@@ -372,6 +447,7 @@ Description: "StructureMap die een KVK Basisprofiel API response transformeert n
 * group[=].rule[=].target[=].variable = "addrLine2"
 * group[=].rule[=].target[=].transform = #cast
 * group[=].rule[=].target[=].parameter[+].valueId = "huisnr"
+* group[=].rule[=].target[=].parameter[+].valueString = "string"
 // nested: iso21090-ADXP-houseNumber extension
 * group[=].rule[=].rule[+].name = "houseNumberExt"
 * group[=].rule[=].rule[=].source[+].context = "huisnr"
@@ -393,6 +469,7 @@ Description: "StructureMap die een KVK Basisprofiel API response transformeert n
 * group[=].rule[=].rule[=].rule[=].target[=].element = "valueString"
 * group[=].rule[=].rule[=].rule[=].target[=].transform = #cast
 * group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueId = "huisnr"
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "string"
 
 // huisletter → line + iso21090-ADXP-buildingNumberSuffix extension
 * group[=].rule[+].name = "huisletter"
@@ -607,6 +684,7 @@ Description: "Logical model representing the KVK (Kamer van Koophandel) Vestigin
 //   adressen[]                      → Location.address
 //   adressen[].geoData              → Location.position (latitude/longitude)
 //   websites[]                      → Location.telecom (system: url)
+//   sbiActiviteiten[]               → Location.type (SBI CodeSystem)
 //   indHoofdvestiging/materieleReg  → Location.status (active/inactive)
 // ============================================================================
 
@@ -615,6 +693,7 @@ InstanceOf: StructureMap
 Usage: #definition
 Title: "KVK Vestigingsprofiel naar FHIR Location"
 Description: "StructureMap die een KVK Vestigingsprofiel API response transformeert naar een FHIR Location resource."
+* id = "KvkVestigingsprofielToLocation"
 * url = "http://minvws.github.io/generiekefuncties-docs/StructureMap/KvkVestigingsprofielToLocation"
 * name = "KvkVestigingsprofielToLocation"
 * status = #draft
@@ -635,6 +714,21 @@ Description: "StructureMap die een KVK Vestigingsprofiel API response transforme
 * group[=].input[=].type = "Location"
 * group[=].input[=].mode = #target
 
+// Rule: set meta.profile to NlGfLocation
+* group[=].rule[+].name = "setProfile"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "meta"
+* group[=].rule[=].target[=].variable = "meta"
+* group[=].rule[=].rule[+].name = "setProfileUrl"
+* group[=].rule[=].rule[=].source[+].context = "src"
+* group[=].rule[=].rule[=].target[+].context = "meta"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "profile"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://minvws.github.io/generiekefuncties-docs/StructureDefinition/nl-gf-location"
+
 // Rule: vestigingsnummer → identifier (system: http://fhir.nl/fhir/NamingSystem/kvk-vestigingsnummer)
 * group[=].rule[+].name = "vestigingsnummer"
 * group[=].rule[=].source[+].context = "src"
@@ -644,6 +738,13 @@ Description: "StructureMap die een KVK Vestigingsprofiel API response transforme
 * group[=].rule[=].target[=].contextType = #variable
 * group[=].rule[=].target[=].element = "identifier"
 * group[=].rule[=].target[=].variable = "vestId"
+* group[=].rule[=].rule[+].name = "vestUse"
+* group[=].rule[=].rule[=].source[+].context = "vestNr"
+* group[=].rule[=].rule[=].target[+].context = "vestId"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "use"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueString = "official"
 * group[=].rule[=].rule[+].name = "vestSystem"
 * group[=].rule[=].rule[=].source[+].context = "vestNr"
 * group[=].rule[=].rule[=].target[+].context = "vestId"
@@ -658,6 +759,58 @@ Description: "StructureMap die een KVK Vestigingsprofiel API response transforme
 * group[=].rule[=].rule[=].target[=].element = "value"
 * group[=].rule[=].rule[=].target[=].transform = #copy
 * group[=].rule[=].rule[=].target[=].parameter[+].valueId = "vestNr"
+* group[=].rule[=].rule[+].name = "vestAssigner"
+* group[=].rule[=].rule[=].source[+].context = "vestNr"
+* group[=].rule[=].rule[=].target[+].context = "vestId"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "assigner"
+* group[=].rule[=].rule[=].target[=].variable = "assignerRef"
+* group[=].rule[=].rule[=].rule[+].name = "assignerIdentifier"
+* group[=].rule[=].rule[=].rule[=].source[+].context = "vestNr"
+* group[=].rule[=].rule[=].rule[=].target[+].context = "assignerRef"
+* group[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].target[=].element = "identifier"
+* group[=].rule[=].rule[=].rule[=].target[=].variable = "assignerId"
+* group[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdSystem"
+* group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "vestNr"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerId"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "system"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://fhir.nl/fhir/NamingSystem/kvk"
+* group[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdValue"
+* group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "vestNr"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerId"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "value"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "50000535"
+* group[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdType"
+* group[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "vestNr"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerId"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "type"
+* group[=].rule[=].rule[=].rule[=].rule[=].target[=].variable = "assignerIdType"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdTypeCoding"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "vestNr"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerIdType"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "coding"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].variable = "assignerIdTypeCoding"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdTypeCodingSystem"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "vestNr"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerIdTypeCoding"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "system"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://terminology.hl7.org/CodeSystem/provenance-participant-type"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[+].name = "assignerIdTypeCodingCode"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].source[+].context = "vestNr"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[+].context = "assignerIdTypeCoding"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].element = "code"
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].rule[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "author"
 
 // Rule: kvkNummer → managingOrganization (Reference by identifier, system: kvk)
 * group[=].rule[+].name = "kvkNummer"
@@ -788,6 +941,19 @@ Description: "StructureMap die een KVK Vestigingsprofiel API response transforme
 * group[=].rule[=].dependent[=].variable[+] = "web"
 * group[=].rule[=].dependent[=].variable[+] = "tel"
 
+// Rule: sbiActiviteiten → type (via dependent group)
+* group[=].rule[+].name = "sbiActiviteiten"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].source[=].element = "sbiActiviteiten"
+* group[=].rule[=].source[=].variable = "sbi"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "type"
+* group[=].rule[=].target[=].variable = "cc"
+* group[=].rule[=].dependent[+].name = "KvkVestSBIToCodeableConcept"
+* group[=].rule[=].dependent[=].variable[+] = "sbi"
+* group[=].rule[=].dependent[=].variable[+] = "cc"
+
 // ── Group 1: Handelsnaam → Location.alias ───────────────────────────────────
 * group[+].name = "KvkVestHandelsnaamToAlias"
 * group[=].typeMode = #none
@@ -871,6 +1037,7 @@ Description: "StructureMap die een KVK Vestigingsprofiel API response transforme
 * group[=].rule[=].target[=].variable = "addrLine2"
 * group[=].rule[=].target[=].transform = #cast
 * group[=].rule[=].target[=].parameter[+].valueId = "huisnr"
+* group[=].rule[=].target[=].parameter[+].valueString = "string"
 // nested: iso21090-ADXP-houseNumber extension
 * group[=].rule[=].rule[+].name = "houseNumberExt"
 * group[=].rule[=].rule[=].source[+].context = "huisnr"
@@ -892,6 +1059,7 @@ Description: "StructureMap die een KVK Vestigingsprofiel API response transforme
 * group[=].rule[=].rule[=].rule[=].target[=].element = "valueString"
 * group[=].rule[=].rule[=].rule[=].target[=].transform = #cast
 * group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueId = "huisnr"
+* group[=].rule[=].rule[=].rule[=].target[=].parameter[+].valueString = "string"
 
 // huisletter → line + iso21090-ADXP-buildingNumberSuffix extension
 * group[=].rule[+].name = "huisletter"
@@ -1079,3 +1247,60 @@ Description: "StructureMap die een KVK Vestigingsprofiel API response transforme
 * group[=].rule[=].target[=].element = "use"
 * group[=].rule[=].target[=].transform = #copy
 * group[=].rule[=].target[=].parameter[+].valueString = "work"
+
+// ── Group 5: SBI Activiteit → CodeableConcept (vestigingsprofiel) ────────────
+* group[+].name = "KvkVestSBIToCodeableConcept"
+* group[=].typeMode = #none
+* group[=].input[+].name = "src"
+* group[=].input[=].mode = #source
+* group[=].input[+].name = "tgt"
+* group[=].input[=].type = "CodeableConcept"
+* group[=].input[=].mode = #target
+
+// Create coding element and populate it
+* group[=].rule[+].name = "sbiCoding"
+* group[=].rule[=].source[+].context = "src"
+* group[=].rule[=].target[+].context = "tgt"
+* group[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].target[=].element = "coding"
+* group[=].rule[=].target[=].variable = "coding"
+// Set system
+* group[=].rule[=].rule[+].name = "sbiSystem"
+* group[=].rule[=].rule[=].source[+].context = "src"
+* group[=].rule[=].rule[=].target[+].context = "coding"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "system"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueString = "http://minvws.github.io/generiekefuncties-docs/CodeSystem/nl-gf-sbi-2025-cs"
+// Map sbiCode → coding.code
+* group[=].rule[=].rule[+].name = "sbiCode"
+* group[=].rule[=].rule[=].source[+].context = "src"
+* group[=].rule[=].rule[=].source[=].element = "sbiCode"
+* group[=].rule[=].rule[=].source[=].variable = "code"
+* group[=].rule[=].rule[=].target[+].context = "coding"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "code"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueId = "code"
+// Map sbiOmschrijving → coding.display
+* group[=].rule[=].rule[+].name = "sbiDisplay"
+* group[=].rule[=].rule[=].source[+].context = "src"
+* group[=].rule[=].rule[=].source[=].element = "sbiOmschrijving"
+* group[=].rule[=].rule[=].source[=].variable = "omschr"
+* group[=].rule[=].rule[=].target[+].context = "coding"
+* group[=].rule[=].rule[=].target[=].contextType = #variable
+* group[=].rule[=].rule[=].target[=].element = "display"
+* group[=].rule[=].rule[=].target[=].transform = #copy
+* group[=].rule[=].rule[=].target[=].parameter[+].valueId = "omschr"
+
+
+Instance: kvk-logicals-and-struturemaps
+InstanceOf: Bundle
+Usage: #example
+Title: "Bundle of FHIR Logical Models and StructureMaps for KVK Basisprofiel and Vestigingsprofiel"
+Description: "This bundle contains FHIR Logical Models and StructureMaps that define the mapping from KVK Basisprofiel and Vestigingsprofiel to FHIR Organization and Location resources, respectively. The Bundle is of type 'transaction' and includes PUT entries for each resource and mapping."
+* type = #transaction
+* insert BundleEntryPUT(StructureDefinition, KvkBasisprofiel)
+* insert BundleEntryPUT(StructureMap, KvkBasisprofielToOrganization)
+* insert BundleEntryPUT(StructureDefinition, KvkVestigingsprofiel)
+* insert BundleEntryPUT(StructureMap, KvkVestigingsprofielToLocation)

--- a/test/transform/input/kvk-basisprofiel-90006623-with-ura.json
+++ b/test/transform/input/kvk-basisprofiel-90006623-with-ura.json
@@ -1,0 +1,118 @@
+{
+  "kvkNummer": "90006623",
+  "indNonMailing": "Nee",
+  "naam": "Stichting Uc027Tc01Tg01 1652253635399",
+  "formeleRegistratiedatum": "20220511",
+  "materieleRegistratie": {
+    "datumAanvang": "20120511"
+  },
+  "totaalWerkzamePersonen": 4,
+  "statutaireNaam": "Stichting Uc027Tc01Tg01 1652253635399",
+  "handelsnamen": [
+    {
+      "naam": "Stichting Uc027Tc01Tg01 1652253635399",
+      "volgorde": 0
+    },
+    {
+      "naam": "Mijn 2e handelsnaam 165225363539",
+      "volgorde": 1
+    },
+    {
+      "naam": "Mijn 3e handelsnaam 165225363539",
+      "volgorde": 2
+    }
+  ],
+  "sbiActiviteiten": [
+    {
+      "sbiCode": "86210",
+      "sbiOmschrijving": "Huisartsenzorg",
+      "indHoofdactiviteit": "Ja"
+    }
+  ],
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://api.kvk.nl/test/api/v1/basisprofielen/90006623"
+    },
+    {
+      "rel": "vestigingen",
+      "href": "https://api.kvk.nl/test/api/v1/basisprofielen/90006623/vestigingen"
+    }
+  ],
+  "_embedded": {
+    "hoofdvestiging": {
+      "vestigingsnummer": "990064773193",
+      "kvkNummer": "90006623",
+      "formeleRegistratiedatum": "20220511",
+      "materieleRegistratie": {
+        "datumAanvang": "20120511"
+      },
+      "eersteHandelsnaam": "Stichting Uc027Tc01Tg01 1652253635399",
+      "indHoofdvestiging": "Ja",
+      "indCommercieleVestiging": "Ja",
+      "totaalWerkzamePersonen": 4,
+      "adressen": [
+        {
+          "type": "bezoekadres",
+          "indAfgeschermd": "Nee",
+          "volledigAdres": "Sint Jacobsstraat 300 3511BT Utrecht",
+          "straatnaam": "Sint Jacobsstraat",
+          "huisnummer": 300,
+          "postcode": "3511BT",
+          "plaats": "Utrecht",
+          "land": "Nederland",
+          "geoData": {
+            "addresseerbaarObjectId": "0344010000041835",
+            "nummerAanduidingId": "0344200000174041",
+            "gpsLatitude": 52.096162894974526,
+            "gpsLongitude": 5.113226043101587,
+            "rijksdriehoekX": 136225.65,
+            "rijksdriehoekY": 456469.782,
+            "rijksdriehoekZ": 0
+          }
+        }
+      ],
+      "websites": [
+        "www.domeinnaam1.nl",
+        "www.domeinnaam2.nl",
+        "www.domeinnaam3.nl"
+      ],
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://api.kvk.nl/test/api/v1/basisprofielen/90006623/hoofdvestiging"
+        },
+        {
+          "rel": "vestigingen",
+          "href": "https://api.kvk.nl/test/api/v1/basisprofielen/90006623/vestigingen"
+        },
+        {
+          "rel": "basisprofiel",
+          "href": "https://api.kvk.nl/test/api/v1/basisprofielen/90006623"
+        },
+        {
+          "rel": "vestigingsprofiel",
+          "href": "https://api.kvk.nl/test/api/v1/vestigingsprofielen/990064773193"
+        }
+      ]
+    },
+    "eigenaar": {
+      "rsin": "990983419",
+      "rechtsvorm": "Stichting",
+      "uitgebreideRechtsvorm": "Stichting",
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://api.kvk.nl/test/api/v1/basisprofielen/90006623/eigenaar"
+        },
+        {
+          "rel": "basisprofiel",
+          "href": "https://api.kvk.nl/test/api/v1/basisprofielen/90006623"
+        }
+      ]
+    }
+  },
+  "uraNummer": [
+    "00012345"
+  ]
+}

--- a/test/transform/input/kvk-basisprofiel-90006623.json
+++ b/test/transform/input/kvk-basisprofiel-90006623.json
@@ -1,0 +1,115 @@
+{
+  "kvkNummer": "90006623",
+  "indNonMailing": "Nee",
+  "naam": "Stichting Uc027Tc01Tg01 1652253635399",
+  "formeleRegistratiedatum": "20220511",
+  "materieleRegistratie": {
+    "datumAanvang": "20120511"
+  },
+  "totaalWerkzamePersonen": 4,
+  "statutaireNaam": "Stichting Uc027Tc01Tg01 1652253635399",
+  "handelsnamen": [
+    {
+      "naam": "Stichting Uc027Tc01Tg01 1652253635399",
+      "volgorde": 0
+    },
+    {
+      "naam": "Mijn 2e handelsnaam 165225363539",
+      "volgorde": 1
+    },
+    {
+      "naam": "Mijn 3e handelsnaam 165225363539",
+      "volgorde": 2
+    }
+  ],
+  "sbiActiviteiten": [
+    {
+      "sbiCode": "86210",
+      "sbiOmschrijving": "Huisartsenzorg",
+      "indHoofdactiviteit": "Ja"
+    }
+  ],
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://api.kvk.nl/test/api/v1/basisprofielen/90006623"
+    },
+    {
+      "rel": "vestigingen",
+      "href": "https://api.kvk.nl/test/api/v1/basisprofielen/90006623/vestigingen"
+    }
+  ],
+  "_embedded": {
+    "hoofdvestiging": {
+      "vestigingsnummer": "990064773193",
+      "kvkNummer": "90006623",
+      "formeleRegistratiedatum": "20220511",
+      "materieleRegistratie": {
+        "datumAanvang": "20120511"
+      },
+      "eersteHandelsnaam": "Stichting Uc027Tc01Tg01 1652253635399",
+      "indHoofdvestiging": "Ja",
+      "indCommercieleVestiging": "Ja",
+      "totaalWerkzamePersonen": 4,
+      "adressen": [
+        {
+          "type": "bezoekadres",
+          "indAfgeschermd": "Nee",
+          "volledigAdres": "Sint Jacobsstraat 300 3511BT Utrecht",
+          "straatnaam": "Sint Jacobsstraat",
+          "huisnummer": 300,
+          "postcode": "3511BT",
+          "plaats": "Utrecht",
+          "land": "Nederland",
+          "geoData": {
+            "addresseerbaarObjectId": "0344010000041835",
+            "nummerAanduidingId": "0344200000174041",
+            "gpsLatitude": 52.096162894974526,
+            "gpsLongitude": 5.113226043101587,
+            "rijksdriehoekX": 136225.65,
+            "rijksdriehoekY": 456469.782,
+            "rijksdriehoekZ": 0
+          }
+        }
+      ],
+      "websites": [
+        "www.domeinnaam1.nl",
+        "www.domeinnaam2.nl",
+        "www.domeinnaam3.nl"
+      ],
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://api.kvk.nl/test/api/v1/basisprofielen/90006623/hoofdvestiging"
+        },
+        {
+          "rel": "vestigingen",
+          "href": "https://api.kvk.nl/test/api/v1/basisprofielen/90006623/vestigingen"
+        },
+        {
+          "rel": "basisprofiel",
+          "href": "https://api.kvk.nl/test/api/v1/basisprofielen/90006623"
+        },
+        {
+          "rel": "vestigingsprofiel",
+          "href": "https://api.kvk.nl/test/api/v1/vestigingsprofielen/990064773193"
+        }
+      ]
+    },
+    "eigenaar": {
+      "rsin": "990983419",
+      "rechtsvorm": "Stichting",
+      "uitgebreideRechtsvorm": "Stichting",
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://api.kvk.nl/test/api/v1/basisprofielen/90006623/eigenaar"
+        },
+        {
+          "rel": "basisprofiel",
+          "href": "https://api.kvk.nl/test/api/v1/basisprofielen/90006623"
+        }
+      ]
+    }
+  }
+}

--- a/test/transform/input/kvk-vestigingsprofiel-990064773193.json
+++ b/test/transform/input/kvk-vestigingsprofiel-990064773193.json
@@ -1,0 +1,74 @@
+{
+  "vestigingsnummer": "990064773193",
+  "kvkNummer": "90006623",
+  "rsin": "990983419",
+  "indNonMailing": "Nee",
+  "formeleRegistratiedatum": "20220511",
+  "materieleRegistratie": {
+    "datumAanvang": "20120511"
+  },
+  "statutaireNaam": "Stichting Uc027Tc01Tg01 1652253635399",
+  "eersteHandelsnaam": "Stichting Uc027Tc01Tg01 1652253635399",
+  "indHoofdvestiging": "Ja",
+  "indCommercieleVestiging": "Ja",
+  "voltijdWerkzamePersonen": 3,
+  "totaalWerkzamePersonen": 4,
+  "deeltijdWerkzamePersonen": 1,
+  "handelsnamen": [
+    {
+      "naam": "Stichting Uc027Tc01Tg01 1652253635399",
+      "volgorde": 0
+    },
+    {
+      "naam": "Mijn 2e handelsnaam 165225363539",
+      "volgorde": 1
+    },
+    {
+      "naam": "Mijn 3e handelsnaam 165225363539",
+      "volgorde": 2
+    }
+  ],
+  "adressen": [
+    {
+      "type": "bezoekadres",
+      "indAfgeschermd": "Nee",
+      "volledigAdres": "Sint Jacobsstraat 300 3511BT Utrecht",
+      "straatnaam": "Sint Jacobsstraat",
+      "huisnummer": 300,
+      "postcode": "3511BT",
+      "plaats": "Utrecht",
+      "land": "Nederland",
+      "geoData": {
+        "addresseerbaarObjectId": "0344010000041835",
+        "nummerAanduidingId": "0344200000174041",
+        "gpsLatitude": 52.096162894974526,
+        "gpsLongitude": 5.113226043101587,
+        "rijksdriehoekX": 136225.65,
+        "rijksdriehoekY": 456469.782,
+        "rijksdriehoekZ": 0
+      }
+    }
+  ],
+  "websites": [
+    "www.domeinnaam1.nl",
+    "www.domeinnaam2.nl",
+    "www.domeinnaam3.nl"
+  ],
+  "sbiActiviteiten": [
+    {
+      "sbiCode": "86210",
+      "sbiOmschrijving": "Huisartsenzorg",
+      "indHoofdactiviteit": "Ja"
+    }
+  ],
+  "links": [
+    {
+      "rel": "self",
+      "href": "https://api.kvk.nl/test/api/v1/vestigingsprofielen/990064773193"
+    },
+    {
+      "rel": "basisprofiel",
+      "href": "https://api.kvk.nl/test/api/v1/basisprofielen/90006623"
+    }
+  ]
+}

--- a/test/transform/transform-kvk-to-organization.sh
+++ b/test/transform/transform-kvk-to-organization.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Transform a KVK Basisprofiel JSON to a FHIR Organization resource
+# using the FHIR Validator CLI and a StructureMap.
+#
+# Usage: ./transform-kvk-to-organization.sh [input-file] [output-file]
+#
+# Prerequisites:
+#   - Java 17+ installed
+#   - download the FHIR Validator CLI from https://github.com/hapifhir/org.hl7.fhir.core/releases/latest/download/validator_cli.jar and place it in ./input-cache/
+#   - refer to the structuredefinitions & structuremaps in the NL-GF Implementation Guide (RESOURCES_DIR="hl7.fhir.nl.gf#some-version")....
+#   - ....OR: install and run sushi (see README.md) to generate FHIR resources from the FSH definitions (RESOURCES_DIR="${PROJECT_DIR}/fsh-generated/resources")
+#
+# References:
+#   - https://confluence.hl7.org/display/FHIR/Using+the+FHIR+Mapping+Language
+#   - https://hl7.org/fhir/R4/structuremap-operation-transform.html
+
+PROJECT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+VALIDATOR_JAR="${PROJECT_DIR}/input-cache/validator_cli.jar"
+RESOURCES_DIR="${PROJECT_DIR}/fsh-generated/resources"
+# RESOURCES_DIR="hl7.fhir.nl.gf"
+
+INPUT_DIR="${PROJECT_DIR}/test/transform/input"
+OUTPUT_DIR="${PROJECT_DIR}/test/transform/output"
+mkdir -p "$OUTPUT_DIR"
+
+
+INPUT_FILE="${INPUT_DIR}/kvk-basisprofiel-90006623.json"
+OUTPUT_FILE="${OUTPUT_DIR}/lrza-organization-90006623.json"
+TRANSFORM_MAP="http://minvws.github.io/generiekefuncties-docs/StructureMap/KvkBasisprofielToOrganization"
+
+# Transform the KVK Basisprofiel JSON to a FHIR Organization resource
+echo "======Transforming KVK Basisprofiel to Organization..."
+java -jar "$VALIDATOR_JAR" \
+  transform "$TRANSFORM_MAP" \
+  "$INPUT_FILE" \
+  -output "$OUTPUT_FILE" \
+  -version 4.0.1 \
+  -ig "$RESOURCES_DIR" \
+  -ig "nictiz.fhir.nl.r4.zib2020#0.12.0-beta.4" \
+  -ig "nictiz.fhir.nl.r4.nl-core#0.12.0-beta.4"
+
+# Validate the transformed outputs against their profiles
+echo "======Validating Organization..."
+java -jar "$VALIDATOR_JAR" \
+  "$OUTPUT_FILE" \
+  -version 4.0.1 \
+  -ig "$RESOURCES_DIR" \
+  -ig "nictiz.fhir.nl.r4.zib2020#0.12.0-beta.4" \
+  -ig "nictiz.fhir.nl.r4.nl-core#0.12.0-beta.4"
+
+
+
+INPUT_FILE="${INPUT_DIR}/kvk-vestigingsprofiel-990064773193.json"
+OUTPUT_FILE="${OUTPUT_DIR}/lrza-location-990064773193.json"
+TRANSFORM_MAP="http://minvws.github.io/generiekefuncties-docs/StructureMap/KvkVestigingsprofielToLocation"
+
+# Transform the KVK Vestigingsprofiel JSON to a FHIR Location resource
+echo "======Transforming KVK Vestigingsprofiel to Location..."
+java -jar "$VALIDATOR_JAR" \
+  transform "$TRANSFORM_MAP" \
+  "$INPUT_FILE" \
+  -output "$OUTPUT_FILE" \
+  -version 4.0.1 \
+  -ig "$RESOURCES_DIR" \
+  -ig "nictiz.fhir.nl.r4.zib2020#0.12.0-beta.4" \
+  -ig "nictiz.fhir.nl.r4.nl-core#0.12.0-beta.4"
+
+# Validate the transformed outputs against their profiles
+echo "======Validating Location..."
+java -jar "$VALIDATOR_JAR" \
+  "$OUTPUT_FILE" \
+  -version 4.0.1 \
+  -ig "$RESOURCES_DIR" \
+  -ig "nictiz.fhir.nl.r4.zib2020#0.12.0-beta.4" \
+  -ig "nictiz.fhir.nl.r4.nl-core#0.12.0-beta.4"

--- a/test/transform/transform-kvk-to-organization.sh
+++ b/test/transform/transform-kvk-to-organization.sh
@@ -25,14 +25,18 @@ mkdir -p "$OUTPUT_DIR"
 
 
 INPUT_FILE="${INPUT_DIR}/kvk-basisprofiel-90006623.json"
+INPUT_FILE_WITH_URA="${INPUT_DIR}/kvk-basisprofiel-90006623-with-ura.json"
 OUTPUT_FILE="${OUTPUT_DIR}/lrza-organization-90006623.json"
 TRANSFORM_MAP="http://minvws.github.io/generiekefuncties-docs/StructureMap/KvkBasisprofielToOrganization"
+
+# Add uraNummer to the basisprofiel input
+jq '. + {"uraNummer": ["00012345"]}' "$INPUT_FILE" > "$INPUT_FILE_WITH_URA"
 
 # Transform the KVK Basisprofiel JSON to a FHIR Organization resource
 echo "======Transforming KVK Basisprofiel to Organization..."
 java -jar "$VALIDATOR_JAR" \
   transform "$TRANSFORM_MAP" \
-  "$INPUT_FILE" \
+  "$INPUT_FILE_WITH_URA" \
   -output "$OUTPUT_FILE" \
   -version 4.0.1 \
   -ig "$RESOURCES_DIR" \


### PR DESCRIPTION
**Test Data and Transformation Scripts:**

* Added new test input files for KVK basisprofiel and vestigingsprofiel JSON data, representing realistic Dutch organization and location data for transformation and validation. [[1]](diffhunk://#diff-9272691e9e6109d2578e4f032d17285b1b499e0731ebeda38a49314a1373b47bR1-R115) [[2]](diffhunk://#diff-1c07f0ce4f90e112f1df4753552e508cad4ba973e2317030082b942f1a2ce831R1-R74)
* Introduced a shell script (`transform-kvk-to-organization.sh`) to automate transformation of KVK JSON profiles to FHIR Organization and Location resources using the FHIR Validator CLI and StructureMaps, including validation against relevant profiles.

**Documentation**
- Improved `README.md` with detailed instructions for local FSH-FHIR resource generation, including setup steps for required tooling.