### PR TITLE
Endpoint lifecycle, period-based transition and selection rule

### DIFF
--- a/input/fsh/examples/lrza-directory.fsh
+++ b/input/fsh/examples/lrza-directory.fsh
@@ -24,6 +24,7 @@ Description: "Example: LRZa - Organization 1 - Organization"
 * address.city = "Ulft"
 * address.postalCode = "7071 PT"
 * endpoint[+] = Reference(Endpoint/d6a4678b-755e-5ae3-bd36-67db6ae3d8c4) // Endpoint of this organization (Organization 1) from Data Source 1
+* endpoint[+] = Reference(Endpoint/53c03a2e-53e9-4994-827c-98f6b4caf897) // Superseded Endpoint of the previous EHR system (kept, see no-deletes constraint)
 
 
 
@@ -169,6 +170,7 @@ Description: "Example: Organization 1 - Endpoint"
 * payloadMimeType[+] = #application/fhir+json
 * connectionType = $endpoint-connection-type#hl7-fhir-rest
 * name = "FHIR Endpoint 1"
+* period.start = "2024-01-15"
 * managingOrganization = Reference(Organization/4f95356e-77a8-56a6-9429-f32538d157f2)
 * contact[0].system = #phone
 * contact[=].value = "+3131599991"
@@ -177,6 +179,26 @@ Description: "Example: Organization 1 - Endpoint"
 * contact[=].value = "info@cp1.example.org"
 * contact[=].use = #work
 * address = "https://cp1-test.example.org/fhirr4"
+
+
+Instance: 53c03a2e-53e9-4994-827c-98f6b4caf897
+InstanceOf: NlGfEndpoint
+Usage: #example
+Title: "Organization 1 - Endpoint (superseded)"
+Description: "Example: superseded Endpoint of the previous EHR system of Organization 1. In line with the no-deletes constraint it remains registered: period.end marks the cutover to the replacing Endpoint and the status was set to off after the old system was decommissioned."
+* insert CustodianAssignedIdentifier("urn:ietf:rfc:3986","urn:uuid:88037f33-3bc5-4e93-8735-091f0f3d1b76","http://fhir.nl/fhir/NamingSystem/kvk", "50000535")
+* status = #off
+
+* payloadType[+].coding = nl-gf-data-categories-cs#AdvanceDirective "Advance Directive"
+* payloadMimeType[+] = #application/fhir+json
+* connectionType = $endpoint-connection-type#hl7-fhir-rest
+* name = "FHIR Endpoint 1 (previous EHR system)"
+* period.end = "2024-01-15"
+* managingOrganization = Reference(Organization/4f95356e-77a8-56a6-9429-f32538d157f2)
+* contact[0].system = #email
+* contact[=].value = "info@cp1.example.org"
+* contact[=].use = #work
+* address = "https://cp1-old.example.org/fhir"
 
 
 Instance: a76d130d-97eb-51b6-9e10-3810bfe0b0c5

--- a/input/images-source/care-services-endpoint-transition-use-case.plantuml
+++ b/input/images-source/care-services-endpoint-transition-use-case.plantuml
@@ -1,0 +1,63 @@
+@startuml care-services-endpoint-transition-use-case
+
+skinparam roundcorner 20
+skinparam defaultFontName Arial
+hide footbox
+
+!pragma teoz true
+
+actor Admin as "Care provider\nadministrator"
+participant SPNew as "New EHR\n(Data Source B)"
+participant SPOld as "Old EHR\n(Data Source A)"
+participant LRZa as "LRZa\nDirectory"
+participant Replica as "Directory\n(local replica)"
+participant QC as "EHR at other\ncare provider\n(Query Client)"
+
+note over Admin, QC
+In this example the practice plans the
+cutover to the new EHR at **2024-01-15**.
+end note
+
+== Before cutover (2024-01-15) ==
+
+activate Admin
+Admin -> SPNew: Prepare migration\nto new EHR
+activate SPNew
+SPNew -> LRZa: POST /Endpoint\n(status=active,\nperiod.start=2024-01-15)
+activate LRZa
+deactivate SPNew
+Admin -> SPOld: End usage per\n2024-01-15
+activate SPOld
+SPOld -> LRZa: PUT /Endpoint/[old]\n(period.end=2024-01-15)
+deactivate SPOld
+deactivate Admin
+
+note right of LRZa
+Both Endpoints are registered, but their
+periods do not overlap: at any moment at
+most one Endpoint is valid. If one Data
+Source is authorized for both changes,
+they SHOULD be combined in a single
+transaction Bundle.
+end note
+
+Replica -> LRZa: Sync updates (ITI-91)
+activate Replica
+deactivate LRZa
+
+QC -> Replica: Find Endpoints of the practice
+activate QC
+QC -> QC: Filter: status=active and\nperiod includes now\n→ **old** Endpoint
+
+== After cutover (2024-01-15) ==
+
+QC -> Replica: Find Endpoints of the practice
+QC -> QC: Filter: status=active and\nperiod includes now\n→ **new** Endpoint
+deactivate QC
+deactivate Replica
+
+== After decommissioning the old system ==
+
+SPOld -> LRZa: PUT /Endpoint/[old]\n(status=off)
+
+@enduml

--- a/input/pagecontent/care-services.md
+++ b/input/pagecontent/care-services.md
@@ -66,6 +66,10 @@ For more information, see the [synchronization example](#use-case-2-update-clien
 The Query Client uses the local replica to find organizations, healthcare services, locations, endpoints, devices, and organizational relationships for routing and discovery. 
 Note that the data exchange between Query Client and (local) Directory MAY use a proprietary interface. [Use case 3](#use-case-3-healthcare-service-query) and [use case 4](#use-case-4-endpoint-discovery) illustrate how to search for healthcare services and endpoints. 
 
+When selecting an Endpoint for data exchange, the Query Client SHALL only use Endpoints that have status `active` and whose `period`, when present, includes the current time. Within that selection, the Query Client matches on `connectionType` and `payloadType` (see [use case 4](#use-case-4-endpoint-discovery)). When multiple valid Endpoints remain for the same Organization or HealthcareService and the same `connectionType`/`payloadType` combination, this indicates either intentional redundancy or a registration error; the Query Client SHALL NOT deliver the same payload to more than one Endpoint and SHOULD prefer the Endpoint with the most recent `period.start`. See [Endpoint lifecycle and transition](#endpoint-lifecycle-and-transition) for how transitions between systems are represented.
+
+Note: FHIR R4 does not define a search parameter for `Endpoint.period`, so the period is evaluated by the Query Client after retrieving candidate Endpoints from the local replica.
+
 
 ### Transactions
 
@@ -136,10 +140,24 @@ The [NL-GF-Endpoints profile](./StructureDefinition-nl-gf-endpoint.html) is used
 | Attribute | Card. | Description |
 |---|---|---|
 | status | 1..1 | The operational status of the endpoint (e.g. active, off). |
+| period | 0..1 | The interval during which the endpoint is expected to be operational. An absent `period.end` means the endpoint is operational until further notice. |
 | connectionType | 1..1 | The type of connection (extensible binding to [Core connection types](https://hl7.org/fhir/R4/valueset-endpoint-connection-type.html) and [NL-GF Connection Types](./ValueSet-nl-gf-connection-types-vs.html)). |
 | payloadType | 1..* | The payload type(s) supported (extensible binding to [NL-GF Payload Types](./ValueSet-nl-gf-payload-type-vs.html)). |
 | address | 1..1 | The technical address (URL) of the endpoint. |
 | managingOrganization → Organization | 1..1 | The organization that manages this endpoint (e.g. IT vendor). |
+
+##### Endpoint lifecycle and transition
+
+Endpoints follow the [no-deletes constraint](#national-constraints-compared-to-ihe-mcsd): an Endpoint is never deleted. Its validity is expressed through `status` and `period`:
+
+- `status` describes the operational state of the endpoint itself (`active`, `suspended`, `off`, `entered-in-error`).
+- `period` describes the interval during which the endpoint is expected to be operational. An Endpoint without `period.end` is operational until further notice. A `period.start` in the future MAY be used to announce an endpoint ahead of its activation; no separate scheduling mechanism is provided.
+
+When a care provider migrates to another system, the Endpoints of the old and the new system may be *registered* simultaneously, but their periods SHALL be set such that at most one of them is *valid* at any moment: the superseded Endpoint receives a `period.end` at the planned cutover moment and the replacing Endpoint a `period.start` at that same moment. This removes any ambiguity about which Endpoint to use during a transition: data exchange partners select the Endpoint whose period includes the current time (see [Query Client](#query-client)). When a single Data Source is authorized for both changes, it SHOULD apply them atomically in one FHIR transaction Bundle. When two different service providers are involved, both can safely register their change ahead of the cutover moment, because Endpoint selection is driven by `period`, not by registration time.
+
+After the old system has actually been taken out of operation, its Endpoint status SHOULD be set to `off`. The status `entered-in-error` is reserved for registrations that should never have existed.
+
+[Use case 5](#use-case-5-endpoint-transition) illustrates a transition between systems.
 
 
 #### Device
@@ -250,6 +268,17 @@ Dr. West just created a referral (for patient Vera Brooks from use case #3). The
 
 <div>
 {% include care-services-endpoint-query-use-case.svg %}
+</div>
+
+#### Use Case #5: Endpoint Transition
+The general practice from use case #1 replaces its EHR system and plans a cutover moment at which the new system takes over:
+- The new service provider registers the Endpoint(s) of the new system with `period.start` set to the cutover moment.
+- The superseded Endpoint receives a `period.end` at the same cutover moment — applied by the currently authorized service provider, or combined with the previous step in one transaction Bundle when a single Data Source is authorized for both changes.
+- Update Clients synchronize both registrations to the local replicas. Query Clients keep selecting the old Endpoint until the cutover moment, and the new Endpoint thereafter; at no moment are both Endpoints valid.
+- After the old system is decommissioned, its Endpoint status is set to `off`.
+
+<div>
+{% include care-services-endpoint-transition-use-case.svg %}
 </div>
 
 


### PR DESCRIPTION
Verwerkt consultatiefeedback uit [epic endpoint-eigenschappen (#864)](https://github.com/minvws/generiekefuncties-architectuur/issues/864), clusters *lifecycle* en *transitie oud→nieuw*:

- **Endpoint-entity (`care-services.md`)**: `period` toegevoegd aan de attributentabel + nieuwe sectie *Endpoint lifecycle and transition*: geldigheid via `status` en `period`, transitie via `period.end` (oud) en `period.start` (nieuw) op hetzelfde cutover-moment, in één transaction Bundle als één Data Source voor beide wijzigingen geautoriseerd is, `off` na decommissioning, `entered-in-error` alleen voor foutregistraties. Een toekomstige `period.start` dekt scheduling af.
- **Query Client**: normatieve selectieregel — alleen `status=active` met een `period` die het huidige moment omvat; nooit dezelfde payload naar meerdere endpoints; noot dat R4 geen search parameter op `Endpoint.period` definieert (client-side evaluatie op de local replica).
- **Use Case #5 + nieuw sequence diagram**: transitie tussen EHR-systemen met concreet cutover-moment.
- **Voorbeelddata (`lrza-directory.fsh`)**: superseded endpoint van het vorige EHR van Organization 1 (`status=off`, `period.end`), naast het actieve endpoint met `period.start`.

Geen profielwijziging nodig: `Endpoint.period` is een core R4-element (0..1).

Dekt de volgende consultatie-issues (in `minvws/generiekefuncties-architectuur`):
[#89](https://github.com/minvws/generiekefuncties-architectuur/issues/89), [#112](https://github.com/minvws/generiekefuncties-architectuur/issues/112), [#123](https://github.com/minvws/generiekefuncties-architectuur/issues/123), [#179](https://github.com/minvws/generiekefuncties-architectuur/issues/179), [#247](https://github.com/minvws/generiekefuncties-architectuur/issues/247), [#268](https://github.com/minvws/generiekefuncties-architectuur/issues/268), [#662](https://github.com/minvws/generiekefuncties-architectuur/issues/662)

SUSHI: 0 errors, 0 warnings.