### PR TITLE
Machine-readable FHIR version on endpoints and conformance guidance

### DIFF
--- a/input/fsh/examples/lrza-directory.fsh
+++ b/input/fsh/examples/lrza-directory.fsh
@@ -166,7 +166,7 @@ Description: "Example: Organization 1 - Endpoint"
 * status = #active
 
 * payloadType[+].coding = nl-gf-data-categories-cs#AdvanceDirective "Advance Directive"
-* payloadMimeType[+] = #application/fhir+json
+* payloadMimeType[+] = #"application/fhir+json; fhirVersion=4.0"
 * connectionType = $endpoint-connection-type#hl7-fhir-rest
 * name = "FHIR Endpoint 1"
 * managingOrganization = Reference(Organization/4f95356e-77a8-56a6-9429-f32538d157f2)
@@ -223,7 +223,7 @@ Description: "Example: Organization 2 - Endpoint FHIR R4"
 * status = #active
 
 * payloadType[+].coding = nl-gf-data-categories-cs#AdvanceDirective "Advance Directive"
-* payloadMimeType[+] = #application/fhir+json
+* payloadMimeType[+] = #"application/fhir+json; fhirVersion=4.0"
 * connectionType = $endpoint-connection-type#hl7-fhir-rest
 * name = "FHIR Endpoint 2"
 * managingOrganization = Reference(Organization/4484c2f2-795a-54fc-8de6-e565ff0dce30)
@@ -276,9 +276,9 @@ Description: "Example: Organization 2 - Endpoint FHIR STU3"
 * payloadType[+].coding = nl-gf-data-categories-cs#DiagnosticReport "Diagnostic Report"
 * payloadType[+].coding = nl-gf-data-categories-cs#Condition "Condition"
 * payloadType[+].coding = nl-gf-data-categories-cs#AllergyIntolerance "Allergy Intolerance"
-* payloadMimeType[+] = #application/fhir+json
+* payloadMimeType[+] = #"application/fhir+json; fhirVersion=3.0"
 * connectionType = $endpoint-connection-type#hl7-fhir-rest
-* name = "FHIR STU3 Endpoint"
+* name = "FHIR Endpoint 2 (health records)"
 * managingOrganization = Reference(Organization/4484c2f2-795a-54fc-8de6-e565ff0dce30)
 * contact[0].system = #phone
 * contact[=].value = "+3131599991"
@@ -478,9 +478,9 @@ Description: "Example: Organization 3 - Endpoint FHIR R4"
 * status = #active
 
 * payloadType[+].coding = nl-gf-data-categories-cs#AdvanceDirective "Advance Directive"
-* payloadMimeType[+] = #application/fhir+json
+* payloadMimeType[+] = #"application/fhir+json; fhirVersion=4.0"
 * connectionType = $endpoint-connection-type#hl7-fhir-rest
-* name = "FHIR R4 Endpoint"
+* name = "FHIR Endpoint 3"
 * managingOrganization = Reference(Organization/2c5ebd34-5961-51ec-a263-cb07a76079c0)
 * contact[0].system = #phone
 * contact[=].value = "+3131599991"
@@ -512,9 +512,9 @@ Description: "Example: Organization 3 - Endpoint FHIR STU3"
 * payloadType[+].coding = nl-gf-data-categories-cs#DiagnosticReport "Diagnostic Report"
 * payloadType[+].coding = nl-gf-data-categories-cs#Condition "Condition"
 * payloadType[+].coding = nl-gf-data-categories-cs#AllergyIntolerance "Allergy Intolerance"
-* payloadMimeType[+] = #application/fhir+json
+* payloadMimeType[+] = #"application/fhir+json; fhirVersion=3.0"
 * connectionType = $endpoint-connection-type#hl7-fhir-rest
-* name = "FHIR STU3 Endpoint"
+* name = "FHIR Endpoint 3 (health records)"
 * managingOrganization = Reference(Organization/2c5ebd34-5961-51ec-a263-cb07a76079c0)
 * contact[0].system = #phone
 * contact[=].value = "+3131599991"

--- a/input/pagecontent/care-services.md
+++ b/input/pagecontent/care-services.md
@@ -138,8 +138,24 @@ The [NL-GF-Endpoints profile](./StructureDefinition-nl-gf-endpoint.html) is used
 | status | 1..1 | The operational status of the endpoint (e.g. active, off). |
 | connectionType | 1..1 | The type of connection (extensible binding to [Core connection types](https://hl7.org/fhir/R4/valueset-endpoint-connection-type.html) and [NL-GF Connection Types](./ValueSet-nl-gf-connection-types-vs.html)). |
 | payloadType | 1..* | The payload type(s) supported (extensible binding to [NL-GF Payload Types](./ValueSet-nl-gf-payload-type-vs.html)). |
+| payloadMimeType | 0..* | The mime type(s) of the payload, including the standard version for FHIR endpoints (e.g. `application/fhir+json; fhirVersion=4.0`). |
 | address | 1..1 | The technical address (URL) of the endpoint. |
 | managingOrganization → Organization | 1..1 | The organization that manages this endpoint (e.g. IT vendor). |
+
+##### Versioning and conformance
+
+Systems may support multiple versions of a standard at the same time, for instance during the transition from FHIR STU3 to FHIR R4 (zib2017 to zib2020). The version of the standard is therefore part of the selection criteria for an Endpoint and is expressed machine-readably in `payloadMimeType`:
+
+- An Endpoint with a FHIR-based `connectionType` (e.g. `hl7-fhir-rest`) SHALL include the FHIR version in its `payloadMimeType` values, using the standard [`fhirVersion` MIME-type parameter](https://hl7.org/fhir/R4/http.html#version-parameter): `application/fhir+json; fhirVersion=4.0` (R4) or `application/fhir+json; fhirVersion=3.0` (STU3).
+- A system that serves multiple FHIR versions on the same address lists multiple `payloadMimeType` values on a single Endpoint. A future payload version migration therefore does not require registering a new Endpoint; separate Endpoints are only needed when the versions are served on different addresses.
+- When selecting an Endpoint, a Query Client matches on `connectionType`, `payloadType` and — when the payload version matters for the exchange — `payloadMimeType` including its `fhirVersion` parameter.
+- Free-text fields such as `Endpoint.name` MAY mention a version for readability, but systems SHALL NOT rely on free-text fields for version selection; `payloadMimeType` is the normative source.
+
+The Directory only carries the metadata needed for *selecting* an Endpoint (`connectionType`, `payloadType`, `payloadMimeType`). How detailed conformance information is obtained depends on the connection type:
+
+- FHIR endpoints: the CapabilityStatement of the system itself, available at runtime via `[address]/metadata`.
+- IHE SOAP-based profiles (e.g. XDS, XCA): these have no runtime conformance interface; conformance is established out-of-band through IHE Integration Statements and the qualification/admission within the applicable trust framework ("afsprakenstelsel"). What a receiving system can process is declared per document (e.g. `formatCode` in the document metadata), not per Endpoint.
+- DICOM(web) endpoints: the vendor's DICOM Conformance Statement.
 
 
 #### Device
@@ -258,3 +274,4 @@ Dr. West just created a referral (for patient Vera Brooks from use case #3). The
 
 - Security specifications must be aligned with LDN 'veilig netwerk' specifications
 - The data profiles should be added/merged in the NL Core profiles
+- Versioning of information standards / implementation guides per Endpoint (e.g. which zib release or IG package) is to be elaborated in alignment with the national choice of standards ([epic standaardenkeuze](https://github.com/minvws/generiekefuncties-architectuur/issues/876)); the NDH [fhir-ig extension](https://hl7.org/fhir/us/ndh/StructureDefinition-base-ext-fhir-ig.html) is a candidate mechanism.


### PR DESCRIPTION
Verwerkt consultatiefeedback uit [epic endpoint-eigenschappen (#864)](https://github.com/minvws/generiekefuncties-architectuur/issues/864), cluster *versionering van standaarden en payloads*:

- **Nieuwe sectie "Versioning and conformance"** bij de Endpoint-entity in `care-services.md`:
  - FHIR-endpoints SHALL de FHIR-versie machine-leesbaar opnemen in `payloadMimeType` via de standaard [`fhirVersion` MIME-parameter](https://hl7.org/fhir/R4/http.html#version-parameter) (`application/fhir+json; fhirVersion=4.0` / `3.0`) — core R4-mechanisme, geen extension nodig.
  - Eén endpoint kan meerdere versies vermelden; een payload-versiemigratie vereist dus geen nieuw endpoint.
  - Query Clients matchen op `connectionType`, `payloadType` en (waar relevant) `payloadMimeType` incl. `fhirVersion` — daarmee is de zib2017/STU3 vs zib2020/R4-zoekvraag beantwoord.
  - Vrije-tekstvelden (`Endpoint.name`) zijn niet normatief voor versieselectie.
  - Conformance-afbakening per connectionType: FHIR runtime via `[address]/metadata`; IHE SOAP-profielen (XDS/XCA) en DICOM out-of-band via integration-/conformance-statements en het afsprakenstelsel.
- **`payloadMimeType` toegevoegd aan de attributentabel** van de Endpoint-entity.
- **Voorbeelddata**: de vijf FHIR-endpoints (Organization 1/2/3) hebben nu een `fhirVersion`-parameter in `payloadMimeType`; versienummers zijn uit de `name`-velden gehaald (PO-voorstel).
- **Roadmap**: versionering van informatiestandaarden/IG's per endpoint uitgesteld tot de standaardenkeuze ([epic #876](https://github.com/minvws/generiekefuncties-architectuur/issues/876)); NDH [`fhir-ig` extension](https://hl7.org/fhir/us/ndh/StructureDefinition-base-ext-fhir-ig.html) als kandidaat genoteerd.

Dekt de volgende consultatie-issues (in `minvws/generiekefuncties-architectuur`):
[#91](https://github.com/minvws/generiekefuncties-architectuur/issues/91), [#213](https://github.com/minvws/generiekefuncties-architectuur/issues/213), [#266](https://github.com/minvws/generiekefuncties-architectuur/issues/266), [#269](https://github.com/minvws/generiekefuncties-architectuur/issues/269), [#520](https://github.com/minvws/generiekefuncties-architectuur/issues/520), [#524](https://github.com/minvws/generiekefuncties-architectuur/issues/524)

Onafhankelijk van #42 (start vanaf `main`); bij het mergen van beide ontstaat hooguit een triviaal conflict in de Endpoint-attributentabel.

SUSHI: 0 errors, 0 warnings.